### PR TITLE
Fix NRE in ModuleFillerParametersScreen.

### DIFF
--- a/YAFC/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/YAFC/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -54,12 +54,21 @@ namespace YAFC
             gui.BuildText("Beacons & beacon modules:", Font.subheader);
             if (gui.BuildFactorioObjectButtonWithText(modules.beacon))
             {
-                SelectObjectPanel.Select(Database.allBeacons, "Select beacon", select => { modules.RecordUndo().beacon = select; }, true);
+                SelectObjectPanel.Select(Database.allBeacons, "Select beacon", select =>
+                {
+                    var shouldClearModule = modules.beaconModule != null && (select?.CanAcceptModule(modules.beaconModule.module) ?? false);
+                    var undo = modules.RecordUndo();
+                    undo.beacon = select;
+                    if (shouldClearModule)
+                    {
+                        undo.beaconModule = null;
+                    }
+                }, true);
             }
 
             if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule))
             {
-                SelectObjectPanel.Select(Database.allModules.Where(x => modules.beacon.CanAcceptModule(x.module)), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; }, true);
+                SelectObjectPanel.Select(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.module) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; }, true);
             }
 
             using (gui.EnterRow())


### PR DESCRIPTION
In the module selection screen, there is an NRE when trying to edit the
`beaconModule` if the `beacon` is `null`. This patch resolves that. It
also clears out `beaconModule` if `beacon` is set changed to `null`, or
if a newly selected beacon is not compatible the current `beaconModule`.