### PR TITLE
Fix the base case where no multiplier is present

### DIFF
--- a/YAFCmodel/Data/DataUtils.cs
+++ b/YAFCmodel/Data/DataUtils.cs
@@ -337,6 +337,9 @@ namespace YAFC.Model
                         case 't': case 'T':
                             multiplier = 1e12f;
                             break;
+                        case '/':
+                            multiplier = 1f;
+                            break;
                         default:
                             return false;
                     }


### PR DESCRIPTION
When parsing items per second input box, the base case where no multiplier is included is not handled. This means you can't input 50/s for example as it falls through the case statement and returns false.