### PR TITLE
Add using statements to FactorioDataSource.cs to dispose of file/zip streams

### DIFF
--- a/YAFCparser/FactorioDataSource.cs
+++ b/YAFCparser/FactorioDataSource.cs
@@ -117,7 +117,8 @@ namespace YAFC.Parser
                         x.FullName.IndexOf('/') == x.FullName.Length - "info.json".Length - 1);
                     if (infoEntry != null)
                     {
-                        var info = JsonSerializer.Deserialize<ModInfo>(infoEntry.Open().ReadAllText((int) infoEntry.Length));
+                        using var openedSteam = infoEntry.Open();
+                        var info = JsonSerializer.Deserialize<ModInfo>(openedSteam.ReadAllText((int) infoEntry.Length));
                         if (!string.IsNullOrEmpty(info.name) && allMods.TryGetValue(info.name, out var modInfo) && modInfo == null)
                         {
                             info.folder = infoEntry.FullName.Substring(0, infoEntry.FullName.Length - "info.json".Length);

--- a/YAFCparser/FactorioDataSource.cs
+++ b/YAFCparser/FactorioDataSource.cs
@@ -110,8 +110,8 @@ namespace YAFC.Parser
             {
                 if (fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase))
                 {
-                    var fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
-                    var zipArchive = new ZipArchive(fileStream);
+                    using var fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+                    using var zipArchive = new ZipArchive(fileStream);
                     var infoEntry = zipArchive.Entries.FirstOrDefault(x =>
                         x.Name.Equals("info.json", StringComparison.OrdinalIgnoreCase) &&
                         x.FullName.IndexOf('/') == x.FullName.Length - "info.json".Length - 1);


### PR DESCRIPTION
`FileStream` and `ZipArchive` in `FactorioDataSource.cs` implement `IDisposable`.  Adding `using` statements to dispose of them when they exit scope.