### PR TITLE
Use SDL.SDL_EnableScreenSaver() to allow screensaver

### DIFF
--- a/YAFCui/Core/Ui.cs
+++ b/YAFCui/Core/Ui.cs
@@ -26,6 +26,7 @@ namespace YAFC.UI
                 SetProcessDpiAwareness(2);
             SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
             SDL.SDL_SetHint(SDL.SDL_HINT_RENDER_SCALE_QUALITY, "linear");
+            SDL.SDL_EnableScreenSaver();
             SDL_ttf.TTF_Init();
             SDL_image.IMG_Init(SDL_image.IMG_InitFlags.IMG_INIT_PNG | SDL_image.IMG_InitFlags.IMG_INIT_JPG);
             asyncCallbacksAdded = SDL.SDL_RegisterEvents(1);


### PR DESCRIPTION
libSDL prevents screensavers/screen-blanking by default (which is usually wanted because it's often used for games and controllers don't count as activity so screensavers could still start), but since YAFC is more a desktop application than a game (and controlled with mouse and keyboard instead of a controller), it's a rather unexpected behavior that it prevents screensaver and I was wondering why my screens don't switch to powersave mode anymore (and even when I activated it manually, YAFC was waking them up again).

There are multiple ways to disable this libSDL behavior and allow screensavers/power-saving again: I could, for example, set an `SDL_VIDEO_ALLOW_SCREENSAVER=1` environment variable, but since I don't think anybody does expect or want that YAFC prevents screensavers, I think it's better when it's disabled by default with YAFC. So I found that there is [`SDL_EnableScreenSaver()`](https://wiki.libsdl.org/SDL_EnableScreenSaver) which allows the app to change the default behavior for all users without the need of an env var.

I hope I found the correct place to add this. I tested this change on Linux and it works as expected, and my screens can sleep again without me needing to close YAFCs every time. I couldn't test this on Windows or Mac.

(Also thanks for adding a dark mode, I really like it :heart_eyes: YAFC was always so bright at night ;) )