### PR TITLE
Split fluids by temperature

### DIFF
--- a/YAFC/Utils/Preferences.cs
+++ b/YAFC/Utils/Preferences.cs
@@ -47,10 +47,10 @@ namespace YAFC
         public bool darkMode { get; set; }
         public string language { get; set; } = "en";
 
-        public void AddProject(string path, string dataPath, string modsPath, bool expensiveRecipes)
+        public void AddProject(string path, string dataPath, string modsPath, bool expensiveRecipes, bool splitFluidsByTemperature)
         {
             recentProjects = recentProjects.Where(x => string.Compare(path, x.path, StringComparison.InvariantCultureIgnoreCase) != 0)
-                .Prepend(new RecentProject {path = path, modsPath = modsPath, dataPath = dataPath, expensive = expensiveRecipes}).ToArray();
+                .Prepend(new RecentProject {path = path, modsPath = modsPath, dataPath = dataPath, expensive = expensiveRecipes, splitFluidsByTemperature = splitFluidsByTemperature}).ToArray();
             Save();
         }
     }
@@ -61,5 +61,6 @@ namespace YAFC
         public string dataPath { get; set; }
         public string modsPath { get; set; }
         public bool expensive { get; set; }
+        public bool splitFluidsByTemperature { get; set; }
     }
 }

--- a/YAFC/Windows/MainScreen.cs
+++ b/YAFC/Windows/MainScreen.cs
@@ -477,7 +477,7 @@ namespace YAFC
             if (path != null)
             {
                 project.Save(path);
-                Preferences.Instance.AddProject(path, DataUtils.dataPath, DataUtils.modsPath, DataUtils.expensiveRecipes);
+                Preferences.Instance.AddProject(path, DataUtils.dataPath, DataUtils.modsPath, DataUtils.expensiveRecipes, DataUtils.splitFluidsByTemperature);
                 return true;
             }
 

--- a/YAFC/Windows/WelcomeScreen.cs
+++ b/YAFC/Windows/WelcomeScreen.cs
@@ -17,6 +17,7 @@ namespace YAFC
         private string currentLoad1, currentLoad2;
         private string path = "", dataPath = "", modsPath = "";
         private bool expensive;
+        private bool splitFluidsByTemperature = true;
         private string createText;
         private bool canCreate;
         private readonly VerticalScrollCustom errorScroll;
@@ -94,6 +95,11 @@ namespace YAFC
                     "e.g. C:/Games/Steam/SteamApps/common/Factorio/data", EditType.Factorio);
                 BuildPathSelect(gui, ref modsPath, "Factorio Mods location (optional)\nIt should contain file 'mod-list.json'",
                     "If you don't use separate mod folder, leave it empty", EditType.Mods);
+
+                using (gui.EnterRow())
+                {
+                    gui.BuildCheckBox("Split fluids by temperature", splitFluidsByTemperature, out splitFluidsByTemperature);
+                }
 
                 using (gui.EnterRow())
                 {
@@ -184,6 +190,7 @@ namespace YAFC
         private void SetProject(RecentProject project)
         {
             expensive = project.expensive;
+            splitFluidsByTemperature = project.splitFluidsByTemperature;
             modsPath = project.modsPath ?? "";
             path = project.path ?? "";
             dataPath = project.dataPath ?? "";
@@ -203,7 +210,7 @@ namespace YAFC
             try
             {
                 var (dataPath, modsPath, projectPath, expensiveRecipes) = (this.dataPath, this.modsPath, path, expensive);
-                Preferences.Instance.AddProject(projectPath, dataPath, modsPath, expensiveRecipes);
+                Preferences.Instance.AddProject(projectPath, dataPath, modsPath, expensiveRecipes, splitFluidsByTemperature);
                 Preferences.Instance.Save();
 
                 loading = true;
@@ -211,7 +218,7 @@ namespace YAFC
 
                 await Ui.ExitMainThread();
                 var collector = new ErrorCollector();
-                var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensiveRecipes, this, collector, Preferences.Instance.language);
+                var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensiveRecipes, splitFluidsByTemperature, this, collector, Preferences.Instance.language);
                 await Ui.EnterMainThread();
                 Console.WriteLine("Opening main screen");
                 new MainScreen(displayIndex, project);

--- a/YAFCmodel/Data/DataClasses.cs
+++ b/YAFCmodel/Data/DataClasses.cs
@@ -132,7 +132,36 @@ namespace YAFC.Model
 
     public class Recipe : RecipeOrTechnology
     {
-        internal string category;
+        public string category { get; internal set; }
+
+        public Recipe Clone()
+        {
+            Recipe copy = new Recipe
+            {
+                category = this.category,
+                crafters = this.crafters,
+                enabled = this.enabled,
+                factorioType = this.factorioType,
+                flags = this.flags,
+                hidden = this.hidden,
+                icon = this.icon,
+                iconSpec = this.iconSpec,
+                id = this.id,
+                ingredients = this.ingredients,
+                locDescr = this.locDescr,
+                locName = this.locName,
+                mainProduct = this.mainProduct,
+                modules = this.modules,
+                name = this.name,
+                products = this.products,
+                sourceEntity = this.sourceEntity,
+                technologyUnlock = this.technologyUnlock,
+                time = this.time,
+                typeDotName = this.typeDotName
+            };
+
+            return copy;
+        }
     }
 
     public class Mechanics : Recipe
@@ -248,7 +277,7 @@ namespace YAFC.Model
             return spent != null;
         }
     }
-    
+
     public class Fluid : Goods
     {
         public override Fluid fluid => this;
@@ -261,6 +290,30 @@ namespace YAFC.Model
         public override bool isPower => false;
         public override UnitOfMeasure flowUnitOfMeasure => UnitOfMeasure.FluidPerSecond;
         internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Fluids;
+
+        public Fluid Clone()
+        {
+            Fluid copy = new Fluid
+            {
+                factorioType = this.factorioType,
+                fuelValue = this.fuelValue,
+                heatCapacity = this.heatCapacity,
+                icon = this.icon,
+                iconSpec = this.iconSpec,
+                id = this.id,
+                locDescr = this.locDescr,
+                locName = this.locName,
+                maxTemperature = this.maxTemperature,
+                minTemperature = this.minTemperature,
+                miscSources = this.miscSources,
+                name = this.name,
+                production = this.production,
+                typeDotName = this.typeDotName,
+                usages = this.usages
+            };
+
+            return copy;
+        }
     }
     
     public class Special : Goods

--- a/YAFCmodel/Data/DataClasses.cs
+++ b/YAFCmodel/Data/DataClasses.cs
@@ -129,8 +129,11 @@ namespace YAFC.Model
             return true;
         }
     }
-    
-    public class Recipe : RecipeOrTechnology {}
+
+    public class Recipe : RecipeOrTechnology
+    {
+        internal string category;
+    }
 
     public class Mechanics : Recipe
     {

--- a/YAFCmodel/Data/DataUtils.cs
+++ b/YAFCmodel/Data/DataUtils.cs
@@ -48,6 +48,7 @@ namespace YAFC.Model
         public static string dataPath { get; internal set; }
         public static string modsPath { get; internal set; }
         public static bool expensiveRecipes { get; internal set; }
+        public static bool splitFluidsByTemperature { get; internal set; }
         public static string[] allMods { get; internal set; }
         public static readonly Random random = new Random();
 

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -306,10 +306,6 @@ namespace YAFC.Parser
             AssignRecipesToCategories();
 
             progress.Report(("Post-processing", "Computing maps"));
-            foreach (var recipe in allObjects.OfType<Recipe>())
-            {
-                recipeCategories.Add(recipe.category, recipe);
-            }
 
             // Deterministically sort all objects
             allObjects.Sort((a, b) => a.sortingOrder == b.sortingOrder ? string.Compare(a.typeDotName, b.typeDotName, StringComparison.Ordinal) : a.sortingOrder - b.sortingOrder);

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -239,6 +239,10 @@ namespace YAFC.Parser
                 foreach(var newFluid in fluid.Item2)
                 {
                     fuels.Add(fuelCategory, newFluid, true);
+                    if (newFluid.fuelValue > 0f)
+                    {
+                        fuels.Add(SpecialNames.BurnableFluid, newFluid);
+                    }
                 }
             }
 

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -32,29 +32,41 @@ namespace YAFC.Parser
             return result;
         }
 
+        private string MakeFluidTemperatureNameSuffix(float min, float max)
+        {
+            var nameSuffix = "__" +
+                (min == max
+                ? ((int)min).ToString()
+                : ((int)min).ToString() + "_" + ((int)max).ToString());
+
+            return nameSuffix;
+        }
+
+        private string MakeFluidTemperatureLocNameSuffix(float min, float max)
+        {
+            var locNameSuffix = " " +
+                (min == max
+                ? ((int)min).ToString() + "°"
+                : ((int)min).ToString() + "°-" + ((int)max).ToString() + "°");
+
+            return locNameSuffix;
+        }
+
         private Fluid MakeFluidWithDifferentTemperatures(Fluid fluid, float newMinTemperature, float newMaxTemperature)
         {
-            var nameSuffix = "-" + 
-                (newMinTemperature == newMaxTemperature
-                ? ((int)newMinTemperature).ToString()
-                : ((int)newMinTemperature).ToString() + "_" + ((int)newMaxTemperature).ToString());
+            var nameSuffix = MakeFluidTemperatureNameSuffix(newMinTemperature, newMaxTemperature);
 
-            var locNameSuffix = " " +
-                (newMinTemperature == newMaxTemperature
-                ? ((int)newMinTemperature).ToString() + "°"
-                : ((int)newMinTemperature).ToString() + "°-" + ((int)newMaxTemperature).ToString() + "°");
+            var locNameSuffix = MakeFluidTemperatureLocNameSuffix(newMinTemperature, newMaxTemperature);
 
             Fluid copy = new Fluid();
             copy.usages = fluid.usages;
             copy.production = fluid.production;
             copy.name = fluid.name + nameSuffix;
+            copy.locName = fluid.locName + locNameSuffix;
             copy.miscSources = fluid.miscSources;
             copy.minTemperature = newMinTemperature;
             copy.maxTemperature = newMaxTemperature;
             copy.locDescr = fluid.locDescr;
-            copy.locName = fluid.locName == null
-                ? fluid.name + locNameSuffix
-                : fluid.locName + locNameSuffix;
             copy.iconSpec = fluid.iconSpec;
             copy.icon = fluid.icon;
             copy.heatCapacity = fluid.heatCapacity;
@@ -68,15 +80,7 @@ namespace YAFC.Parser
             var newMinTemperature = newFluid.minTemperature;
             var newMaxTemperature = newFluid.maxTemperature;
 
-            var nameSuffix = "-" +
-                (newMinTemperature == newMaxTemperature
-                ? ((int)newMinTemperature).ToString()
-                : ((int)newMinTemperature).ToString() + "_" + ((int)newMaxTemperature).ToString());
-
-            var locNameSuffix = " " +
-                (newMinTemperature == newMaxTemperature
-                ? ((int)newMinTemperature).ToString() + "°"
-                : ((int)newMinTemperature).ToString() + "°-" + ((int)newMaxTemperature).ToString() + "°");
+            var nameSuffix = MakeFluidTemperatureNameSuffix(newMinTemperature, newMaxTemperature);
 
             Recipe copy = new Recipe();
             copy.crafters = recipe.crafters;
@@ -101,9 +105,6 @@ namespace YAFC.Parser
             copy.mainProduct = recipe.mainProduct;
             copy.modules = recipe.modules;
             copy.name = recipe.name + nameSuffix;
-            copy.locName = recipe.locName == null
-                ? recipe.name + locNameSuffix
-                : recipe.locName + locNameSuffix;
             copy.products = recipe.products;
             copy.sourceEntity = recipe.sourceEntity;
             copy.technologyUnlock = recipe.technologyUnlock;
@@ -117,15 +118,7 @@ namespace YAFC.Parser
             var newMinTemperature = newFluid.minTemperature;
             var newMaxTemperature = newFluid.maxTemperature;
 
-            var nameSuffix = "-" +
-                (newMinTemperature == newMaxTemperature
-                ? ((int)newMinTemperature).ToString()
-                : ((int)newMinTemperature).ToString() + "_" + ((int)newMaxTemperature).ToString());
-
-            var locNameSuffix = " " +
-                (newMinTemperature == newMaxTemperature
-                ? ((int)newMinTemperature).ToString() + "°"
-                : ((int)newMinTemperature).ToString() + "°-" + ((int)newMaxTemperature).ToString() + "°");
+            var nameSuffix = MakeFluidTemperatureNameSuffix(newMinTemperature, newMaxTemperature);
 
             Recipe copy = new Recipe();
             copy.crafters = recipe.crafters;
@@ -148,9 +141,6 @@ namespace YAFC.Parser
             }
             copy.modules = recipe.modules;
             copy.name = recipe.name + nameSuffix;
-            copy.locName = recipe.locName == null
-                ? recipe.name + locNameSuffix
-                : recipe.locName + locNameSuffix;
             copy.products = recipe.products.Select(i => {
                 if (i == product)
                 {

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -354,8 +354,11 @@ namespace YAFC.Parser
             progress.Report(("Loading", "Loading entities"));
             foreach (var prototypeName in ((LuaTable) data["Entity types"]).ArrayElements<string>())
                 DeserializePrototypes(raw, prototypeName, DeserializeEntity, progress);
-            progress.Report(("Post-processing", "Understanding fluid temperatures"));
-            SplitFluidsByTemperature();
+            if (splitFluidsByTemperature)
+            {
+                progress.Report(("Post-processing", "Understanding fluid temperatures"));
+                SplitFluidsByTemperature();
+            }
             progress.Report(("Post-processing", "Computing maps"));
             // Moved to here because we remove recipes earlier - we would otherwise point to inexisting recipes
             foreach (var recipe in allObjects.OfType<Recipe>())

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -279,7 +279,8 @@ namespace YAFC.Parser
             foreach (var fluid in fluids)
             {
                 var partitionedFluid = SplitFluidByTemperature(fluid, recipes);
-                if (partitionedFluid.Count > 0)
+                // Only split fluids when there's actually a reason.
+                if (partitionedFluid.Count > 1)
                 {
                     newFluids.Add((fluid, partitionedFluid));
                 }
@@ -289,6 +290,8 @@ namespace YAFC.Parser
             foreach(var recipe in recipes)
             {
                 var partitionedRecipe = SplitRecipeByIngredientsProductsTemperatures(recipe, newFluids);
+                // If we split the fluid we have to split the recipes even if there's only one.
+                // Otherwise we end up with references to removed fluids.
                 if (partitionedRecipe.Count > 0)
                 {
                     newRecipes.Add((recipe, partitionedRecipe));

--- a/YAFCparser/Data/FactorioDataDeserializer_Context.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Context.cs
@@ -219,7 +219,10 @@ namespace YAFC.Parser
         {
             var fullName = category + (category.EndsWith(".") ? "" : ".") + production.name;
             if (registeredObjects.TryGetValue((typeof(Mechanics), fullName), out var recipeRaw))
+            {
+                (recipeRaw as Recipe).category = category;
                 return recipeRaw as Recipe;
+            }
             var recipe = GetObject<Mechanics>(fullName);
             recipe.time = 1f;
             recipe.factorioType = SpecialNames.FakeRecipe;
@@ -230,7 +233,7 @@ namespace YAFC.Parser
             recipe.enabled = true;
             recipe.hidden = true;
             recipe.technologyUnlock = new PackedList<Technology>();
-            recipeCategories.Add(category, recipe);
+            recipe.category = category;
             return recipe;
         }
         

--- a/YAFCparser/Data/FactorioDataDeserializer_Context.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Context.cs
@@ -20,6 +20,7 @@ namespace YAFC.Parser
         private readonly HashSet<FactorioObject> milestones = new HashSet<FactorioObject>();
         
         private readonly bool expensiveRecipes;
+        private readonly bool splitFluidsByTemperature;
 
         private Recipe generatorProduction;
         private Recipe reactorProduction;
@@ -34,10 +35,11 @@ namespace YAFC.Parser
         
         private static readonly Version v0_18 = new Version(0, 18);
 
-        public FactorioDataDeserializer(bool expensiveRecipes, Version factorioVersion)
+        public FactorioDataDeserializer(bool expensiveRecipes, bool splitFluidsByTemperature, Version factorioVersion)
         {
             this.expensiveRecipes = expensiveRecipes;
             this.factorioVersion = factorioVersion;
+            this.splitFluidsByTemperature = splitFluidsByTemperature;
             RegisterSpecial();
         }
 

--- a/YAFCparser/Data/FactorioDataDeserializer_Entity.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Entity.cs
@@ -236,7 +236,7 @@ namespace YAFC.Parser
                         var fixedRecipeCategoryName = SpecialNames.FixedRecipe + fixedRecipeName;
                         fixedRecipe = GetObject<Recipe>(fixedRecipeName);
                         recipeCrafters.Add(entity, fixedRecipeCategoryName);
-                        recipeCategories.Add(fixedRecipeCategoryName, fixedRecipe);
+                        fixedRecipe.category = fixedRecipeCategoryName;
                     }
                     else
                     {

--- a/YAFCparser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -23,7 +23,7 @@ namespace YAFC.Parser
         {
             var recipe = DeserializeWithDifficulty<Recipe>(table, "recipe", LoadRecipeData);
             table.Get("category", out string recipeCategory, "crafting");
-            recipeCategories.Add(recipeCategory, recipe);
+            recipe.category = recipeCategory;
             recipe.modules = recipeModules.GetArray(recipe);
             if (table.Get("main_product", out string mainProductName))
                 recipe.mainProduct = recipe.products.FirstOrDefault(x => x.goods.name == mainProductName)?.goods;

--- a/YAFCparser/FactorioDataSource.cs
+++ b/YAFCparser/FactorioDataSource.cs
@@ -138,7 +138,7 @@ namespace YAFC.Parser
             }
         }
 
-        public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, IProgress<(string, string)> progress, ErrorCollector errorCollector, string locale)
+        public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, bool splitFluidsByTemperature, IProgress<(string, string)> progress, ErrorCollector errorCollector, string locale)
         {
             LuaContext dataContext = null;
             try
@@ -223,7 +223,7 @@ namespace YAFC.Parser
                 DataUtils.dataPath = factorioPath;
                 DataUtils.modsPath = modPath;
                 DataUtils.expensiveRecipes = expensive;
-
+                DataUtils.splitFluidsByTemperature = splitFluidsByTemperature;
             
                 dataContext = new LuaContext();
                 object settings;
@@ -247,7 +247,7 @@ namespace YAFC.Parser
                 dataContext.DoModFiles(modLoadOrder, "data-final-fixes.lua", progress);
                 dataContext.Exec(postprocess, postprocess.Length, "*", "post");
 
-                var deserializer = new FactorioDataDeserializer(expensive, factorioVersion);
+                var deserializer = new FactorioDataDeserializer(expensive, splitFluidsByTemperature, factorioVersion);
                 var project = deserializer.LoadData(projectPath, dataContext.data, progress, errorCollector);
                 Console.WriteLine("Completed!");
                 progress.Report(("Completed!", ""));


### PR DESCRIPTION
This PR introduces splitting fluids by temperature into more fluids and assigns recipes such that fluid temperatures are respected.
Notably it allows solving the hot air chain in pymods that heavily relies on fluid temperature (and similar chains).

An option was added to the main screen above expensive recipe checkbox to toggle this splitting. This option could be defaulted to true and removed in the future. Projects that use non-split fluids are incompatibile with the option set.