### PR TITLE
Fix building on non-Windows machine

### DIFF
--- a/YAFC/YAFC.csproj
+++ b/YAFC/YAFC.csproj
@@ -15,7 +15,7 @@
       <None Update="Data/**/*">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
-	  <ContentWithTargetPath Include="lib\windows\*" Condition="'$(OS)' == 'Windows_NT'">
+	  <ContentWithTargetPath Include="lib\windows\*" Condition="'$(RuntimeIdentifier)' == 'win-x64'">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		<TargetPath>%(Filename)%(Extension)</TargetPath>
       </ContentWithTargetPath>


### PR DESCRIPTION
This fixes to include the Windows DLLs in the Windows build when not on a Windows host OS.

`$(OS)` reports the host OS, `$(RuntimeIdentifier)` returns an identifier of the target OS/architecture.