### PR TITLE
Obey version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ desktop.ini
 Build/
 *DotSettings
 *DotSettings.user
+.vs


### PR DESCRIPTION
YAFC doesn't obey `"version": "..."` properties in mod-list.json. This change updates it to obey those properties.

My test mod-list.json and YAFC file are attached. Both aai-industry_0.5.9.zip and aai-industry_0.5.13.zip are in my mod folder.

The observed behavior is that YAFC loads AAI Industry 0.5.13 and reports that the Automation Science Pack is inaccessible. This is correct in the sense that the Automation Science Pack _is_ inaccessible with AAII 0.5.13, but I expected YAFC to load AAII 0.5.9 instead.

With this PR, YAFC will load AAII 0.5.9, and report that the Automation Science Pack is accessible, as expected.

[test.zip](https://github.com/ShadowTheAge/yafc/files/8148085/test.zip)