### PR TITLE
Select multiple recipes in the full recipe lists

### DIFF
--- a/YAFC/Widgets/ImmediateWidgets.cs
+++ b/YAFC/Widgets/ImmediateWidgets.cs
@@ -151,7 +151,12 @@ namespace YAFC
                 if (allowNone && gui.BuildRedButton("Clear") && gui.CloseDropdown())
                     select(null);
                 if (list.Count > count && gui.BuildButton("See full list") && gui.CloseDropdown())
-                    SelectObjectPanel.Select(list, header, select, ordering, allowNone);
+                {
+                    if(multiple)
+                        SelectMultiObjectPanel.Select(list, header, select, ordering, allowNone);
+                    else
+                        SelectSingleObjectPanel.Select(list, header, select, ordering, allowNone);
+                }
                 if (multiple && list.Count > 1)
                     gui.BuildText("Hint: ctrl+click to add multiple", wrap:true, color:SchemeColor.BackgroundTextFaint);
             }

--- a/YAFC/Widgets/PseudoScreen.cs
+++ b/YAFC/Widgets/PseudoScreen.cs
@@ -74,8 +74,12 @@ namespace YAFC
         {
             if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE)
                 Close(false);
+            if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_RETURN || key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 || key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER)
+                ReturnPressed();
             return true;
         }
+
+        protected virtual void ReturnPressed() { }
 
         public virtual bool TextInput(string input) => true;
 

--- a/YAFC/Windows/DependencyExplorer.cs
+++ b/YAFC/Windows/DependencyExplorer.cs
@@ -112,7 +112,7 @@ namespace YAFC
             {
                 gui.BuildText("Currently inspecting:", Font.subheader);
                 if (gui.BuildFactorioObjectButtonWithText(current))
-                    SelectObjectPanel.Select(Database.objects.all, "Select something", Change);
+                    SelectSingleObjectPanel.Select(Database.objects.all, "Select something", Change);
                 gui.BuildText("(Click to change)", color:SchemeColor.BackgroundTextFaint);
             }
             using (gui.EnterRow())

--- a/YAFC/Windows/MainScreen.cs
+++ b/YAFC/Windows/MainScreen.cs
@@ -331,7 +331,7 @@ namespace YAFC
 
         private void ShowNeie()
         {
-            SelectObjectPanel.Select(Database.goods.all, "Open NEIE", NeverEnoughItemsPanel.Show);
+            SelectSingleObjectPanel.Select(Database.goods.all, "Open NEIE", NeverEnoughItemsPanel.Show);
         }
 
         private void SetSearch(SearchQuery searchQuery)
@@ -393,7 +393,7 @@ namespace YAFC
                 ShowNeie();
 
             if (gui.BuildContextMenuButton("Dependency Explorer") && gui.CloseDropdown())
-                SelectObjectPanel.Select(Database.objects.all, "Open Dependency Explorer", DependencyExplorer.Show);
+                SelectSingleObjectPanel.Select(Database.objects.all, "Open Dependency Explorer", DependencyExplorer.Show);
             
             BuildSubHeader(gui, "Extra");
 

--- a/YAFC/Windows/MilestonesEditor.cs
+++ b/YAFC/Windows/MilestonesEditor.cs
@@ -61,7 +61,7 @@ namespace YAFC
                 {
                     if (Project.current.settings.milestones.Count >= 60)
                         MessageBox.Show(null, "Milestone limit reached", "60 milestones is the limit. You may delete some of the milestones you've already reached.", "Ok");
-                    else SelectObjectPanel.Select(Database.objects.all, "Add new milestone", AddMilestone);
+                    else SelectMultiObjectPanel.Select(Database.objects.all, "Add new milestone", AddMilestone);
                 }
             }
         }

--- a/YAFC/Windows/NeverEnoughItemsPanel.cs
+++ b/YAFC/Windows/NeverEnoughItemsPanel.cs
@@ -353,7 +353,7 @@ namespace YAFC
             }
 
             if (gui.BuildFactorioObjectButton(gui.lastRect, current, SchemeColor.Grey))
-                SelectObjectPanel.Select(Database.goods.all, "Select item", SetItem);
+                SelectSingleObjectPanel.Select(Database.goods.all, "Select item", SetItem);
                 
             using (var split = gui.EnterHorizontalSplit(2))
             {

--- a/YAFC/Windows/ProjectPageSettingsPanel.cs
+++ b/YAFC/Windows/ProjectPageSettingsPanel.cs
@@ -26,7 +26,7 @@ namespace YAFC
             gui.BuildTextInput(name, out name, "Input name");
             if (gui.BuildFactorioObjectButton(icon, 4f, MilestoneDisplay.None, SchemeColor.Grey))
             {
-                SelectObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
+                SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
             }
 
             if (icon == null && gui.isBuilding)

--- a/YAFC/Windows/SelectMultiObjectPanel.cs
+++ b/YAFC/Windows/SelectMultiObjectPanel.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YAFC.Model;
+using YAFC.UI;
+
+namespace YAFC
+{
+    public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObject>>
+    {
+        private static readonly SelectMultiObjectPanel Instance = new SelectMultiObjectPanel();
+        private readonly HashSet<FactorioObject> results = new HashSet<FactorioObject>();
+        public SelectMultiObjectPanel() : base() { }
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject
+            => Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject
+        {
+            Instance.results.Clear();
+            Instance.Select(list, header, select, ordering, allowNone, (xs, selectItem) =>
+            {
+                foreach (var x in xs ?? Enumerable.Empty<T>())
+                    selectItem(x);
+            });
+        }
+
+        protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index)
+        {
+            if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, bgColor: results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader: extendHeader))
+            {
+                if (!results.Add(element))
+                    results.Remove(element);
+                if (!InputSystem.Instance.control)
+                    CloseWithResult(results);
+            }
+        }
+    }
+}

--- a/YAFC/Windows/SelectMultiObjectPanel.cs
+++ b/YAFC/Windows/SelectMultiObjectPanel.cs
@@ -10,6 +10,8 @@ namespace YAFC
     {
         private static readonly SelectMultiObjectPanel Instance = new SelectMultiObjectPanel();
         private readonly HashSet<FactorioObject> results = new HashSet<FactorioObject>();
+        private bool allowAutoClose;
+
         public SelectMultiObjectPanel() : base() { }
 
         public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject
@@ -17,6 +19,7 @@ namespace YAFC
 
         public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject
         {
+            Instance.allowAutoClose = true;
             Instance.results.Clear();
             Instance.Select(list, header, select, ordering, allowNone, (xs, selectItem) =>
             {
@@ -31,8 +34,20 @@ namespace YAFC
             {
                 if (!results.Add(element))
                     results.Remove(element);
-                if (!InputSystem.Instance.control)
+                if (!InputSystem.Instance.control && allowAutoClose)
                     CloseWithResult(results);
+                allowAutoClose = false;
+            }
+        }
+
+        public override void Build(ImGui gui)
+        {
+            base.Build(gui);
+            using (gui.EnterGroup(default, RectAllocator.Center))
+            {
+                if (gui.BuildButton("OK"))
+                    CloseWithResult(results);
+                gui.BuildText("Hint: ctrl+click to select multiple", color: SchemeColor.BackgroundTextFaint);
             }
         }
     }

--- a/YAFC/Windows/SelectMultiObjectPanel.cs
+++ b/YAFC/Windows/SelectMultiObjectPanel.cs
@@ -50,5 +50,10 @@ namespace YAFC
                 gui.BuildText("Hint: ctrl+click to select multiple", color: SchemeColor.BackgroundTextFaint);
             }
         }
+
+        protected override void ReturnPressed()
+        {
+            CloseWithResult(results);
+        }
     }
 }

--- a/YAFC/Windows/SelectObjectPanel.cs
+++ b/YAFC/Windows/SelectObjectPanel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using SDL2;
@@ -11,60 +10,55 @@ using YAFC.UI;
 
 namespace YAFC
 {
-    public class SelectObjectPanel : PseudoScreen<FactorioObject>
+    public abstract class SelectObjectPanel<T> : PseudoScreen<T>
     {
-        private static readonly SelectObjectPanel Instance = new SelectObjectPanel();
-        private readonly SearchableList<FactorioObject> list;
-        private string header;
-        private Rect searchBox;
-        private bool extendHeader;
-        public SelectObjectPanel() : base(40f)
+        protected readonly SearchableList<FactorioObject> list;
+        protected string header;
+        protected Rect searchBox;
+        protected bool extendHeader;
+
+        protected SelectObjectPanel() : base(40f)
         {
             list = new SearchableList<FactorioObject>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
         }
 
-        private bool ElementFilter(FactorioObject data, SearchQuery query) => data.Match(query);
-        
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone) where T:FactorioObject
+        protected void Select<U>(IEnumerable<U> list, string header, Action<U> select, IComparer<U> ordering, bool allowNone, Action<T, Action<FactorioObject>> process) where U : FactorioObject
         {
-            MainScreen.Instance.ShowPseudoScreen(Instance);
-            Instance.extendHeader = typeof(T) == typeof(FactorioObject);
-            var data = new List<T>(list);
+            MainScreen.Instance.ShowPseudoScreen(this);
+            extendHeader = typeof(U) == typeof(FactorioObject);
+            var data = new List<U>(list);
             data.Sort(ordering);
             if (allowNone)
                 data.Insert(0, null);
-            Instance.list.filter = default;
-            Instance.list.data = data;
-            Instance.header = header;
-            Instance.Rebuild();
-            Instance.complete = (selected, x) =>
+            this.list.filter = default;
+            this.list.data = data;
+            this.header = header;
+            Rebuild();
+            complete = (selected, x) => process(x, x =>
             {
-                if (x is T t)
+                if (x is U u)
                 {
-                    if (ordering is DataUtils.FavouritesComparer<T> favouritesComparer)
-                        favouritesComparer.AddToFavourite(t);
-                    select(t);
+                    if (ordering is DataUtils.FavouritesComparer<U> favouritesComparer)
+                        favouritesComparer.AddToFavourite(u);
+                    select(u);
                 }
                 else if (allowNone && selected)
                     select(null);
-            };
+            });
         }
-
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject => Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
 
         private void ElementDrawer(ImGui gui, FactorioObject element, int index)
         {
             if (element == null)
             {
                 if (gui.BuildRedButton(Icon.Close))
-                    CloseWithResult(null);
+                    CloseWithResult(default);
             }
             else
-            {
-                if (gui.BuildFactorioObjectButton(element, display:MilestoneDisplay.Contained, extendHeader:extendHeader))
-                    CloseWithResult(element);
-            }
+                NonNullElementDrawer(gui, element, index);
         }
+        protected abstract void NonNullElementDrawer(ImGui gui, FactorioObject element, int index);
+        private bool ElementFilter(FactorioObject data, SearchQuery query) => data.Match(query);
 
         public override void Build(ImGui gui)
         {

--- a/YAFC/Windows/SelectSingleObjectPanel.cs
+++ b/YAFC/Windows/SelectSingleObjectPanel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using YAFC.Model;
+using YAFC.UI;
+
+namespace YAFC
+{
+    public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject>
+    {
+        private static readonly SelectSingleObjectPanel Instance = new SelectSingleObjectPanel();
+        public SelectSingleObjectPanel() : base() { }
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject
+            => Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject
+            => Instance.Select(list, header, select, ordering, allowNone, (x, selectItem) => selectItem(x));
+
+        protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index)
+        {
+            if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, extendHeader: extendHeader))
+                CloseWithResult(element);
+        }
+    }
+}

--- a/YAFC/Workspace/AutoPlannerView.cs
+++ b/YAFC/Workspace/AutoPlannerView.cs
@@ -56,7 +56,7 @@ namespace YAFC
                     grid.Next();
                     if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimalyAlt, size:2.5f))
                     {
-                        SelectObjectPanel.Select(Database.goods.all, "New production goal", x =>
+                        SelectSingleObjectPanel.Select(Database.goods.all, "New production goal", x =>
                         {
                             goal.Add(new AutoPlannerGoal {amount = 1f, item = x});
                             gui.Rebuild();

--- a/YAFC/Workspace/ProductionTable/ModuleCustomisationScreen.cs
+++ b/YAFC/Workspace/ProductionTable/ModuleCustomisationScreen.cs
@@ -39,7 +39,7 @@ namespace YAFC
                 using (gui.EnterRow())
                 {
                     if (gui.BuildFactorioObjectButton(template.icon))
-                        SelectObjectPanel.Select(Database.objects.all, "Select icon", x =>
+                        SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", x =>
                         {
                             template.RecordUndo().icon = x;
                             Rebuild();
@@ -61,7 +61,7 @@ namespace YAFC
                     grid.Next();
                     if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimalyAlt, size:1.5f))
                     {
-                        SelectObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !template.filterEntities.Contains(x)), "Add module template filter", sel =>
+                        SelectSingleObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !template.filterEntities.Contains(x)), "Add module template filter", sel =>
                         {
                             template.RecordUndo().filterEntities.Add(sel);
                             gui.Rebuild();
@@ -175,7 +175,7 @@ namespace YAFC
                     var evt = gui.BuildFactorioObjectWithEditableAmount(module.module, module.fixedCount, UnitOfMeasure.None, out var newAmount);
                     if (evt == GoodsWithAmountEvent.ButtonClick)
                     {
-                        SelectObjectPanel.Select(GetModules(beacon), "Select module", sel =>
+                        SelectSingleObjectPanel.Select(GetModules(beacon), "Select module", sel =>
                         {
                             if (sel == null)
                                 modules.RecordUndo().list.Remove(module);

--- a/YAFC/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/YAFC/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -47,14 +47,14 @@ namespace YAFC
             gui.BuildText("Use this module when aufofill doesn't add anything (for example when productivity modules doesn't fit)", wrap:true);
             if (gui.BuildFactorioObjectButtonWithText(modules.fillerModule))
             {
-                SelectObjectPanel.Select(Database.allModules, "Select filler module", select => { modules.RecordUndo().fillerModule = select; }, true);
+                SelectSingleObjectPanel.Select(Database.allModules, "Select filler module", select => { modules.RecordUndo().fillerModule = select; }, true);
             }
             
             gui.AllocateSpacing();
             gui.BuildText("Beacons & beacon modules:", Font.subheader);
             if (gui.BuildFactorioObjectButtonWithText(modules.beacon))
             {
-                SelectObjectPanel.Select(Database.allBeacons, "Select beacon", select =>
+                SelectSingleObjectPanel.Select(Database.allBeacons, "Select beacon", select =>
                 {
                     modules.RecordUndo();
                     modules.beacon = select;
@@ -65,7 +65,7 @@ namespace YAFC
             }
 
             if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule))
-                SelectObjectPanel.Select(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.module) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; }, true);
+                SelectSingleObjectPanel.Select(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.module) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; }, true);
 
             using (gui.EnterRow())
             {

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -118,7 +118,7 @@ namespace YAFC
                             view.AddDesiredProductAtLevel(recipe.subgroup);
 
                         if (recipe.subgroup != null && imgui.BuildButton("Add raw recipe") && imgui.CloseDropdown())
-                            SelectObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(recipe.subgroup, r));
+                            SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(recipe.subgroup, r));
 
                         if (recipe.subgroup != null && imgui.BuildButton("Unpack nested table"))
                         {
@@ -156,7 +156,7 @@ namespace YAFC
             {
                 if (gui.BuildButton("Add recipe") && gui.CloseDropdown())
                 {
-                    SelectObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(view.model, r));
+                    SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(view.model, r));
                 }
 
                 gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", wrap: true);
@@ -301,7 +301,7 @@ namespace YAFC
             {
                 if (gui.BuildButton("Mass set assembler") && gui.CloseDropdown())
                 {
-                    SelectObjectPanel.Select(Database.allCrafters, "Set assembler for all recipes", set =>
+                    SelectSingleObjectPanel.Select(Database.allCrafters, "Set assembler for all recipes", set =>
                     {
                         DataUtils.FavouriteCrafter.AddToFavourite(set, 10);
                         foreach (var recipe in view.GetRecipesRecursive())
@@ -318,7 +318,7 @@ namespace YAFC
 
                 if (gui.BuildButton("Mass set fuel") && gui.CloseDropdown())
                 {
-                    SelectObjectPanel.Select(Database.goods.all.Where(x => x.fuelValue > 0), "Set fuel for all recipes", set =>
+                    SelectSingleObjectPanel.Select(Database.goods.all.Where(x => x.fuelValue > 0), "Set fuel for all recipes", set =>
                     {
                         DataUtils.FavouriteFuel.AddToFavourite(set, 10);
                         foreach (var recipe in view.GetRecipesRecursive())
@@ -1038,7 +1038,7 @@ namespace YAFC
 
         private void AddDesiredProductAtLevel(ProductionTable table)
         {
-            SelectObjectPanel.Select(Database.goods.all, "Add desired product", product =>
+            SelectMultiObjectPanel.Select(Database.goods.all, "Add desired product", product =>
             {
                 if (table.linkMap.TryGetValue(product, out var existing))
                 {


### PR DESCRIPTION
I found while working on my AngelBob factory that I often wanted to add several recipes that produced, for example, syngas, but there were more than can be displayed in the initial dropdown.

Where logical (The Add production recipe, Add consumption recipe, Select raw recipe, and Add new milestone windows) this allows you to control-click to select multiple items. The currently selected items are highlighted, and you can control-click again to deselect them. After control-clicking at least one item, use the OK button to add all selected items and close the window.
![image](https://user-images.githubusercontent.com/21223975/175794752-09023b47-97f4-47a9-93c8-478d15d2342b.png)

If you do not control-click, the single clicked-on item is selected and added, and the window is closed, as before.


**Possible further enhancements**
* The selection dialog could show which items are already present in the underlying production sheet. This would have been useful to me, and it doesn't look like this should  be technically difficult. Unfortunately, it wasn't obvious how to clearly indicate the necessary four states.
* The "Recipe already exists" message box could be improved to show which of the selected recipes you were potentially duplicating. This would not have been useful to me, but could be a nice "fit-and-finish" feature.