### PR TITLE
Delete unused recipe rows in the production table

### DIFF
--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -161,7 +161,15 @@ namespace YAFC
 
                 if (gui.BuildButton("Remove unused recipes") && gui.CloseDropdown())
                 {
-                    view.model.RecordUndo().RemoveUnusedRecipes();
+                    view.model.RecordUndo().RemoveUnusedRecipes(false);
+                    view.Rebuild();
+                }
+
+                var padding = ImGuiUtils.DefaultButtonPadding;
+                padding = new Padding(padding.left + 1, padding.right, padding.top, padding.bottom);
+                if (gui.BuildButton("... and unpack empty tables", indentLevel: 1) && gui.CloseDropdown())
+                {
+                    view.model.RecordUndo().RemoveUnusedRecipes(true);
                     view.Rebuild();
                 }
 

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -159,6 +159,12 @@ namespace YAFC
                     SelectObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(view.model, r));
                 }
 
+                if (gui.BuildButton("Remove unused recipes") && gui.CloseDropdown())
+                {
+                    view.model.RecordUndo().RemoveUnusedRecipes();
+                    view.Rebuild();
+                }
+
                 gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", wrap: true);
                 using (gui.EnterRow())
                 {

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -233,7 +233,28 @@ namespace YAFC.Model
         {
             for (int i = recipes.Count - 1; i >= 0; i--)
                 if (recipes[i].subgroup != null)
+                {
                     recipes[i].subgroup.RemoveUnusedRecipes();
+                    if (recipes[i].buildingCount == 0 && recipes[i].subgroup.recipes.Count == 0)
+                        recipes.Remove(recipes[i]);
+                    else if (recipes[i].buildingCount == 0)
+                        // This table header needs to be deleted, without deleting its children.
+                        if (recipes[i].subgroup.recipes.FirstOrDefault(r => r.subgroup == null || r.subgroup.recipes.Count == 0) is RecipeRow newParent)
+                        {
+                            // Promote the first child with no children
+                            recipes[i].subgroup.recipes.Remove(newParent);
+                            newParent.subgroup = recipes[i].subgroup;
+                            recipes[i] = newParent;
+                        }
+                        else
+                        {
+                            // or just the first child, if necessary
+                            newParent = recipes[i].subgroup.recipes[0];
+                            recipes[i].subgroup.recipes.Remove(newParent);
+                            newParent.subgroup.recipes.AddRange(recipes[i].subgroup.recipes);
+                            recipes[i] = newParent;
+                        }
+                }
                 else if (recipes[i].buildingCount == 0)
                     recipes.Remove(recipes[i]);
         }

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -229,14 +229,16 @@ namespace YAFC.Model
             flow = flowArr;
         }
 
-        public void RemoveUnusedRecipes()
+        public void RemoveUnusedRecipes(bool unpackToo)
         {
             for (int i = recipes.Count - 1; i >= 0; i--)
                 if (recipes[i].subgroup != null)
                 {
-                    recipes[i].subgroup.RemoveUnusedRecipes();
+                    recipes[i].subgroup.RemoveUnusedRecipes(unpackToo);
                     if (recipes[i].buildingCount == 0 && recipes[i].subgroup.recipes.Count == 0)
                         recipes.Remove(recipes[i]);
+                    else if (recipes[i].subgroup.recipes.Count == 0 && unpackToo)
+                        recipes[i].subgroup = null;
                     else if (recipes[i].buildingCount == 0)
                         // This table header needs to be deleted, without deleting its children.
                         if (recipes[i].subgroup.recipes.FirstOrDefault(r => r.subgroup == null || r.subgroup.recipes.Count == 0) is RecipeRow newParent)

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Google.OrTools.LinearSolver;
@@ -226,6 +227,15 @@ namespace YAFC.Model
             }
             Array.Sort(flowArr, 0, flowArr.Length, this);
             flow = flowArr;
+        }
+
+        public void RemoveUnusedRecipes()
+        {
+            for (int i = recipes.Count - 1; i >= 0; i--)
+                if (recipes[i].subgroup != null)
+                    recipes[i].subgroup.RemoveUnusedRecipes();
+                else if (recipes[i].buildingCount == 0)
+                    recipes.Remove(recipes[i]);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -252,6 +252,8 @@ namespace YAFC.Model
                             newParent = recipes[i].subgroup.recipes[0];
                             recipes[i].subgroup.recipes.Remove(newParent);
                             newParent.subgroup.recipes.AddRange(recipes[i].subgroup.recipes);
+                            newParent.subgroup.links.AddRange(recipes[i].subgroup.links);
+                            newParent.subgroup.RebuildLinkMap();
                             recipes[i] = newParent;
                         }
                 }

--- a/YAFCui/ImGui/ImGuiUtils.cs
+++ b/YAFCui/ImGui/ImGuiUtils.cs
@@ -93,14 +93,18 @@ namespace YAFC.UI
             return false;
         }
         
-        public static bool BuildButton(this ImGui gui, string text, SchemeColor color = SchemeColor.Primary, Padding? padding = null, bool active = true)
+        public static bool BuildButton(this ImGui gui, string text, SchemeColor color = SchemeColor.Primary, Padding? padding = null, bool active = true, int indentLevel = 0)
         {
             if (!active)
                 color = SchemeColor.Grey;
-            using (gui.EnterGroup(padding ?? DefaultButtonPadding, active ? color+2 : color+3))
-                gui.BuildText(text, Font.text, align:RectAlignment.Middle);
 
-            return gui.BuildButton(gui.lastRect, color, color + 1) && active;
+            using (gui.EnterGroup(new Padding(indentLevel * 1.5f, 0, 0, 0)))
+            {
+                using (gui.EnterGroup(padding ?? DefaultButtonPadding, active ? color + 2 : color + 3))
+                    gui.BuildText(text, Font.text, align: RectAlignment.Middle);
+
+                return gui.BuildButton(gui.lastRect, color, color + 1) && active;
+            }
         }
 
         public static ButtonEvent BuildContextMenuButton(this ImGui gui, string text, string rightText = null, Icon icon = default, bool disabled = false)


### PR DESCRIPTION
This is a follow-up to #168. After adding all the recipes in existence, I want to delete the ones the solver decided not to use. It can be merged without #168, if desired.

This adds two buttons to the dropdown on the Recipe column:
![image](https://user-images.githubusercontent.com/21223975/177462196-a800e8d3-372e-443c-ba6a-1a4a29f2c5a1.png)

The first button deletes all recipe rows that have zero assigned buildings, recursively through all nested tables.
The second button also unpacks any nested tables that only have a header recipe.

Given this nested table,
![image](https://user-images.githubusercontent.com/21223975/177462542-22470798-793e-459d-992a-4b7455c7ca04.png)
the first button converts it to this
![image](https://user-images.githubusercontent.com/21223975/177462749-e2a915ac-b880-48fe-a013-32d55f2f505e.png)
and the second button converts it to this
![image](https://user-images.githubusercontent.com/21223975/177462802-0d6e9695-d38a-4365-af04-533f6d797102.png)

Omit 1c0d336 to omit the second button. I can create a new PR if that's desired.

**Required additional work**
* The undo system cannot reliably undo the actions performed by either of these new buttons. I haven't been able to figure out what I'm doing wrong, so I've marked this as a draft.

**Potential future concerns**
* The handling of the header recipes for the nested tables may conflict with plans for #158. Any conflicts there are probably show-stoppers for this PR.
* The combination of this PR and either #118 and #144 will cause these new buttons to delete recipe rows that have a `builtBuildings`, but that the solver didn't use. I'm guessing those rows should be preserved, and can update this PR to do that once one or both of those are merged.