### PR TITLE
Fix #164: Don't treat an empty string as a valid placeResult.

### DIFF
--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -290,7 +290,7 @@ namespace YAFC.Parser
         {
             var item = DeserializeCommon<Item>(table, "item");
 
-            if (table.Get("place_result", out string placeResult))
+            if (table.Get("place_result", out string placeResult) && !String.IsNullOrEmpty(placeResult))
                 placeResults[item] = placeResult;
             item.stackSize = table.Get("stack_size", 1);
             if (item.locName == null && table.Get("placed_as_equipment_result", out string result))


### PR DESCRIPTION
The root cause is that several items in DarkStar have "" as a `place_result`. I'm not sure if this is strictly valid, but Factorio doesn't complain, so I'm assuming it's valid enough. This causes `GetObject<Entity>()` to add a new entity to the object list in `CalculateMaps`.