### PR TITLE
upgrade project to dotnet core6.0

### DIFF
--- a/CommandLineToolExample/CommandLineToolExample.csproj
+++ b/CommandLineToolExample/CommandLineToolExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netcoreapp6.0</TargetFramework>
         <RootNamespace>YafcCommandLineToolExample</RootNamespace>
         <LangVersion>8</LangVersion>
         <OutputType>Exe</OutputType>

--- a/YAFC/YAFC.csproj
+++ b/YAFC/YAFC.csproj
@@ -1,53 +1,54 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-    <PropertyGroup>
-        <LangVersion>8</LangVersion>
-        <OutputType>WinExe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-		<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PlatformTarget>x64</PlatformTarget>
-		<AssemblyVersion>0.6.0</AssemblyVersion>
-		<FileVersion>0.6.0</FileVersion>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <None Update="Data/**/*">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-	  <ContentWithTargetPath Include="lib\windows\*" Condition="('$(RuntimeIdentifier)' == 'win-x64') Or ('$(OS)' == 'Windows_NT')">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		<TargetPath>%(Filename)%(Extension)</TargetPath>
-      </ContentWithTargetPath>
-	  <ContentWithTargetPath Include="lib\osx\*" Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		<TargetPath>%(Filename)%(Extension)</TargetPath>
-      </ContentWithTargetPath>
-	  <ContentWithTargetPath Include="lib\linux\*" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		<TargetPath>%(Filename)%(Extension)</TargetPath>
-      </ContentWithTargetPath>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Folder Include="Data" />
-      <Folder Include="lib" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\YAFCmodel\YAFCmodel.csproj" />
-      <ProjectReference Include="..\YAFCparser\YAFCparser.csproj" />
-      <ProjectReference Include="..\YAFCui\YAFCui.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Include="..\LICENSE">
-        <Link>LICENSE</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-      <Content Include="..\licenses.txt">
-        <Link>licenses.txt</Link>
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
+  <PropertyGroup>
+    <LangVersion>8</LangVersion>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <PlatformTarget>x64</PlatformTarget>
+    <AssemblyVersion>0.6.0</AssemblyVersion>
+    <FileVersion>0.6.0</FileVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Update="Data/**/*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <ContentWithTargetPath Include="lib\windows\*" Condition="('$(RuntimeIdentifier)' == 'win-x64') Or ('$(OS)' == 'Windows_NT')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\osx\*" Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="lib\linux\*" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </ContentWithTargetPath>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Data" />
+    <Folder Include="lib" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\YAFCmodel\YAFCmodel.csproj" />
+    <ProjectReference Include="..\YAFCparser\YAFCparser.csproj" />
+    <ProjectReference Include="..\YAFCui\YAFCui.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\LICENSE">
+      <Link>LICENSE</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\licenses.txt">
+      <Link>licenses.txt</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.336902">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
+  </ItemGroup>
 </Project>

--- a/YAFCmodel/Blueprints/Blueprint.cs
+++ b/YAFCmodel/Blueprints/Blueprint.cs
@@ -19,7 +19,7 @@ namespace YAFC.Blueprints
         {
             if (InputSystem.Instance.control)
                 return ToJson();
-            var sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions {IgnoreNullValues = true});
+            var sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions {DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull});
             using var memory = new MemoryStream();
             memory.Write(header);
             using (var compress = new DeflateStream(memory, CompressionLevel.Optimal, true))
@@ -44,7 +44,7 @@ namespace YAFC.Blueprints
         
         public string ToJson()
         {
-            var sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions {IgnoreNullValues = true});
+            var sourceBytes = JsonSerializer.SerializeToUtf8Bytes(this, new JsonSerializerOptions { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull });
             using var memory = new MemoryStream(sourceBytes);
             using (var reader = new StreamReader(memory))
                 return reader.ReadToEnd();

--- a/YAFCmodel/Data/DataUtils.cs
+++ b/YAFCmodel/Data/DataUtils.cs
@@ -158,7 +158,7 @@ namespace YAFC.Model
         
         public static Solver CreateSolver(string name)
         {
-            var solver = Solver.CreateSolver(name, "GLOP_LINEAR_PROGRAMMING");
+            var solver = Solver.CreateSolver("GLOP_LINEAR_PROGRAMMING");
             // Relax solver parameters as returning imprecise solution is better than no solution at all
             // It is not like we need 8 digits of precision after all, most computations in YAFC are done in singles
             // see all properties here: https://github.com/google/or-tools/blob/stable/ortools/glop/parameters.proto

--- a/YAFCmodel/YAFCmodel.csproj
+++ b/YAFCmodel/YAFCmodel.csproj
@@ -2,15 +2,15 @@
 
     <PropertyGroup>
         <RootNamespace>YAFC.Model</RootNamespace>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netcoreapp6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Google.OrTools" Version="7.4.7247" />
-      <PackageReference Include="Google.OrTools.runtime.linux-x64" Version="7.4.7247" />
-      <PackageReference Include="Google.OrTools.runtime.osx-x64" Version="7.4.7247" />
-      <PackageReference Include="Google.OrTools.runtime.win-x64" Version="7.4.7247" />
-      <PackageReference Include="System.Text.Json" Version="5.0.0-preview.2.20160.6" />
+      <PackageReference Include="Google.OrTools" Version="9.4.1874" />
+      <PackageReference Include="Google.OrTools.runtime.linux-x64" Version="9.4.1874" />
+      <PackageReference Include="Google.OrTools.runtime.osx-x64" Version="9.4.1874" />
+      <PackageReference Include="Google.OrTools.runtime.win-x64" Version="9.4.1874" />
+      <PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/YAFCparser/YAFCparser.csproj
+++ b/YAFCparser/YAFCparser.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>YAFC.Parser</RootNamespace>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netcoreapp6.0</TargetFramework>
 		<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
 		<PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>
@@ -16,7 +16,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="System.Text.Json" Version="5.0.0-preview.2.20160.6" />
+      <PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/YAFCui/YAFCui.csproj
+++ b/YAFCui/YAFCui.csproj
@@ -4,12 +4,12 @@
         <LangVersion>8</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RootNamespace>YAFC.UI</RootNamespace>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>netcoreapp6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="SDL2-CS.NetCore" Version="2.0.8" />
-      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0-preview.2.20160.6" />
+      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR does a minimal effort upgrade to dotnet core 6.0 .
All projects in this repository have had their target platform manually upgraded.
I then ran Microsoft's [upgrade utility](https://github.com/dotnet/upgrade-assistant/issues).

Additionally, I allowed nuget to update the project's dependencies to current, which didn't seem to break anything.
Dotnet was complaining of a deprecated option in the json serialization, so I applied the quick fix it suggested.

Absent a unit test suite, I ran the newly compiled version of YAFC both on my windows box and my Ubuntu Jammy box, and haven't encountered any obvious issues or crashes.

Closes #182


![image](https://user-images.githubusercontent.com/3110986/188328797-a7367485-b0f8-4d0a-a202-e7ef230dafe2.png)
