### PR TITLE
IR scripts diamond-bearing and ruby-bearing rocks onto the map, so treat them as accessible.

### DIFF
--- a/YAFC/Data/Mod-fixes/IndustrialRevolution3.code.terrain.terrain-ores.lua
+++ b/YAFC/Data/Mod-fixes/IndustrialRevolution3.code.terrain.terrain-ores.lua
@@ -1,0 +1,9 @@
+local util = ...;
+
+for _,gem in pairs({"diamond","ruby"}) do -- gem-rock-electrum exists in the mod, but isn't placed on the map
+	if data.raw["simple-entity"]["gem-rock-"..gem] and not data.raw["simple-entity"]["gem-rock-"..gem].autoplace then
+		data.raw["simple-entity"]["gem-rock-"..gem].autoplace = {}
+	end
+end
+
+return util;


### PR DESCRIPTION
They're only required for bootstrapping the real ruby and diamond automation, so I didn't make any effort to calculate the frequency.