### PR TITLE
Bot placeable is accessible

### DIFF
--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -906,9 +906,12 @@ namespace YAFC
             {
                 if (recipe.entity != null)
                 {
-                    shopList.TryGetValue(recipe.entity, out var prev);
+                    FactorioObject shopItem = recipe.entity.itemsToPlace?.FirstOrDefault();
+                    if (shopItem is null)
+                        shopItem = recipe.entity;
+                    shopList.TryGetValue(shopItem, out var prev);
                     var count = MathUtils.Ceil(recipe.buildingCount);
-                    shopList[recipe.entity] = prev + count;
+                    shopList[shopItem] = prev + count;
                     if (recipe.parameters.modules.modules != null)
                     {
                         foreach (var module in recipe.parameters.modules.modules)

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -291,7 +291,7 @@ namespace YAFC.Parser
             var item = DeserializeCommon<Item>(table, "item");
 
             if (table.Get("place_result", out string placeResult) && !String.IsNullOrEmpty(placeResult))
-                placeResults[item] = placeResult;
+                placeResults[item] = new List<string>() { placeResult };
             item.stackSize = table.Get("stack_size", 1);
             if (item.locName == null && table.Get("placed_as_equipment_result", out string result))
             {

--- a/YAFCparser/Data/FactorioDataDeserializer_Context.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Context.cs
@@ -16,7 +16,7 @@ namespace YAFC.Parser
         private readonly DataBucket<string, RecipeOrTechnology> recipeCategories = new DataBucket<string, RecipeOrTechnology>();
         private readonly DataBucket<EntityCrafter, string> recipeCrafters = new DataBucket<EntityCrafter, string>();
         private readonly DataBucket<Recipe, Item> recipeModules = new DataBucket<Recipe, Item>();
-        private readonly Dictionary<Item, string> placeResults = new Dictionary<Item, string>();
+        private readonly Dictionary<Item, List<string>> placeResults = new Dictionary<Item, List<string>>();
         private readonly List<Item> universalModules = new List<Item>();
         private Item[] allModules;
         private readonly HashSet<Item> sciencePacks = new HashSet<Item>();
@@ -227,10 +227,13 @@ namespace YAFC.Parser
                             allMechanics.Add(mechanics);
                         break;
                     case Item item:
-                        if (placeResults.TryGetValue(item, out var placeResultStr))
+                        if (placeResults.TryGetValue(item, out var placeResultNames))
                         {
-                            item.placeResult = GetObject<Entity>(placeResultStr); 
-                            entityPlacers.Add(item.placeResult, item);    
+                            item.placeResult = GetObject<Entity>(placeResultNames.First());
+                            foreach (var name in placeResultNames)
+                            {
+                                entityPlacers.Add(GetObject<Entity>(name), item);
+                            }
                         }
                         if (item.fuelResult != null)
                             miscSources.Add(item.fuelResult, item);

--- a/YAFCparser/Data/FactorioDataDeserializer_Entity.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Entity.cs
@@ -155,6 +155,15 @@ namespace YAFC.Parser
             var name = table.Get("name", "");
             string usesPower;
             var defaultDrain = 0f;
+
+            if (table.Get("placeable_by", out LuaTable placeableBy) && placeableBy.Get("item", out string itemName))
+            {
+                var item = GetObject<Item>(itemName);
+                if (!placeResults.TryGetValue(item, out var resultNames))
+                    resultNames = placeResults[item] = new List<string>();
+                resultNames.Add(name);
+            }
+
             switch (factorioType)
             {
                 case "transport-belt":
@@ -282,7 +291,7 @@ namespace YAFC.Parser
                                     {
                                         if (possibleRecipe is Recipe rec)
                                             CreateLaunchRecipe(crafter, rec, partsRequired, outputCount);
-                                    } 
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This makes bot-placeable (script-created but blueprintable) entities accessible, such as the rod/plate/gear casters from Industrial Revolution. Making the casters accessible also makes the recipes used by those casters accessible.

For recipe accessibility it's only important for crafters, but it also reduces the chances of false positive warnings related to things like the 1-to-N underground pipes in Advanced Fluid Handling.