### PR TITLE
Fix for boiler effectivity

### DIFF
--- a/YAFCmodel/Model/RecipeParameters.cs
+++ b/YAFCmodel/Model/RecipeParameters.cs
@@ -139,7 +139,7 @@ namespace YAFC.Model
                         var deltaTemp = (outputTemp - inputTemperature);
                         var energyPerUnitOfFluid = deltaTemp * fluid.heatCapacity;
                         if (deltaTemp > 0 && fuel != null)
-                            recipeTime = 60 * energyPerUnitOfFluid / (fuelUsagePerSecondPerBuilding * fuel.fuelValue);
+                            recipeTime = 60 * energyPerUnitOfFluid / (fuelUsagePerSecondPerBuilding * fuel.fuelValue * energy.effectivity);
                     }
                 }
                 


### PR DESCRIPTION
Firstly, YAFC is great, thank you for sharing your work!

This PR is a fix for oil boilers (boilers that take fluid fuel) in pyanodons/pypetroleumhandling, which have an `effectivity` value of 2, where YAFC seems to report around half the amount of steam that I get in-game.

In the current code, effectivity is used to correctly scale down the amount of fuel these boilers consume, but when computing how long it takes to heat up the liquid/steam this effectivity is not taken into account.  As a result, I think the recipe time is longer than it should be, which results in YAFC thinking steam is produced at a lower rate.

The change in this PR is to consider the _effective_ energy from the fuel, and results in steam production numbers that seem to match those I get in-game.