### PR TITLE
Auto-assign beacons to recipes before modules.

### DIFF
--- a/YAFCmodel/Model/ModuleFillerParameters.cs
+++ b/YAFCmodel/Model/ModuleFillerParameters.cs
@@ -80,8 +80,8 @@ namespace YAFC.Model
 
         public void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used)
         {
-            AutoFillModules(recipeParams, recipe, entity, fuel, ref effects, ref used);
             AutoFillBeacons(recipeParams, recipe, entity, fuel, ref effects, ref used);
+            AutoFillModules(recipeParams, recipe, entity, fuel, ref effects, ref used);
         }
 
         private void AddModuleSimple(Item module, ref ModuleEffects effects, EntityCrafter entity, ref RecipeParameters.UsedModule used)


### PR DESCRIPTION
This way, effectivity modules will fill to the limit or to the point of counteracting the beacons' effects, rather than stopping at 80% of the 0-beacon consumption.

In the attached IR3 yafc file (save also attached) the original behavior incorrectly auto-assigned two EFF 3 modules to the recipe, when it should have received four. The recipe should get four modules because there are four speed beacons also affecting the building, substantially increasing its consumption. Switching the order to assign beacons first causes the EFF modules to get auto-added correctly.

[IR test.yafc.zip](https://github.com/ShadowTheAge/yafc/files/10514026/IR.test.yafc.zip)
[IR3 game.zip](https://github.com/ShadowTheAge/yafc/files/10514025/IR3.game.zip)
