### PR TITLE
Make milestone list scrollable to support more milestones

### DIFF
--- a/FactorioCalc.sln
+++ b/FactorioCalc.sln
@@ -1,5 +1,6 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YAFC", "YAFC\YAFC.csproj", "{73EBA162-A3BE-43CC-9B55-CA16332F439D}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YAFCui", "YAFCui\YAFCui.csproj", "{70F74D2B-9747-4185-B369-64F77BC8D0D5}"
@@ -9,6 +10,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YAFCparser", "YAFCparser\YAFCparser.csproj", "{4B64D4DD-B6ED-457D-9000-EA0381585959}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandLineToolExample", "CommandLineToolExample\CommandLineToolExample.csproj", "{57E8CAE8-A3F8-4532-B32F-09347852479E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YAFCmodel.Tests", "YAFCmodel.Tests\YAFCmodel.Tests.csproj", "{66B66728-84F0-4242-B49A-B9D746A3CCA5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,5 +39,9 @@ Global
 		{57E8CAE8-A3F8-4532-B32F-09347852479E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{57E8CAE8-A3F8-4532-B32F-09347852479E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{57E8CAE8-A3F8-4532-B32F-09347852479E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66B66728-84F0-4242-B49A-B9D746A3CCA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66B66728-84F0-4242-B49A-B9D746A3CCA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66B66728-84F0-4242-B49A-B9D746A3CCA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66B66728-84F0-4242-B49A-B9D746A3CCA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/YAFC/Widgets/ObjectTooltip.cs
+++ b/YAFC/Widgets/ObjectTooltip.cs
@@ -23,18 +23,18 @@ namespace YAFC
                 if (extendHeader && !(target is Goods))
                     name = name +" (" + target.target.type + ")";
                 gui.BuildText(name, Font.header, true);
-                var milestoneMask = Milestones.Instance.milestoneResult[target.target];
-                if (milestoneMask > 1)
+                var milestoneMask = Milestones.Instance.GetMilestoneResult(target.target);
+                if (milestoneMask.HighestBitSet() > 0)
                 {
                     var spacing = MathF.Min(22f / Milestones.Instance.currentMilestones.Length - 1f, 0f);
                     using (gui.EnterRow(spacing))
                     {
-                        var mask = 2ul;
+                        var maskBit = 1;
                         foreach (var milestone in Milestones.Instance.currentMilestones)
                         {
-                            if ((milestoneMask & mask) != 0)
+                            if (milestoneMask[maskBit])
                                 gui.BuildIcon(milestone.icon, 1f, SchemeColor.Source);
-                            mask <<= 1;
+                            maskBit++;
                         }
                     }
                 }

--- a/YAFC/Windows/MilestonesEditor.cs
+++ b/YAFC/Windows/MilestonesEditor.cs
@@ -72,25 +72,24 @@ namespace YAFC
                 MessageBox.Show(null, "Milestone already exists", "Ok");
                 return;
             }
-            var lockedMask = Milestones.Instance.milestoneResult[obj];
-            if (lockedMask == 0)
+            var lockedMask = Milestones.Instance.GetMilestoneResult(obj);
+            if (lockedMask.IsClear())
             {
                 settings.RecordUndo().milestones.Add(obj);
             }
             else
             {
                 var bestIndex = 0;
-                for (var i = 1; i < 64; i++)
+                for (var i = 1; i < lockedMask.length; i++)
                 {
-                    var mask = (1ul << i);
-                    if ((lockedMask & mask) != 0)
+                    if (lockedMask[i])
                     {
-                        lockedMask &= ~mask;
+                        lockedMask[i] = false;
                         var milestone = Milestones.Instance.currentMilestones[i - 1];
                         var index = settings.milestones.IndexOf(milestone);
                         if (index >= bestIndex)
                             bestIndex = index + 1;
-                        if (lockedMask == 0)
+                        if (lockedMask.IsClear())
                             break;
                     }
                 }

--- a/YAFC/Windows/MilestonesEditor.cs
+++ b/YAFC/Windows/MilestonesEditor.cs
@@ -59,9 +59,7 @@ namespace YAFC
                 }
                 if (gui.BuildButton("Add milestone"))
                 {
-                    if (Project.current.settings.milestones.Count >= 60)
-                        MessageBox.Show(null, "Milestone limit reached", "60 milestones is the limit. You may delete some of the milestones you've already reached.", "Ok");
-                    else SelectObjectPanel.Select(Database.objects.all, "Add new milestone", AddMilestone);
+                    SelectObjectPanel.Select(Database.objects.all, "Add new milestone", AddMilestone);
                 }
             }
         }

--- a/YAFC/Windows/MilestonesPanel.cs
+++ b/YAFC/Windows/MilestonesPanel.cs
@@ -21,13 +21,13 @@ namespace YAFC
             {
                 if (!unlocked)
                 {
-                    var massUnlock = Milestones.Instance.milestoneResult[element];
+                    var massUnlock = Milestones.Instance.GetMilestoneResult(element);
                     var subIndex = 0;
                     settings.SetFlag(element, ProjectPerItemFlags.MilestoneUnlocked, true);
                     foreach (var milestone in settings.milestones)
                     {
                         subIndex++;
-                        if ((massUnlock & (1ul << subIndex)) != 0)
+                        if (massUnlock[subIndex])
                             settings.SetFlag(milestone, ProjectPerItemFlags.MilestoneUnlocked, true);
                     }
                 }

--- a/YAFC/Windows/MilestonesPanel.cs
+++ b/YAFC/Windows/MilestonesPanel.cs
@@ -1,46 +1,48 @@
+using System.Numerics;
 using YAFC.Model;
 using YAFC.UI;
 
 namespace YAFC
 {
-    public class MilestonesWidget
+    public class MilestonesWidget : VirtualScrollList<FactorioObject>
     {
         public static readonly MilestonesWidget Instance = new MilestonesWidget();
-        public void Build(ImGui gui)
+
+        public MilestonesWidget() : base(30f, new Vector2(3f, 3f), MilestoneDrawer)
+        {
+            data = Project.current.settings.milestones;
+        }
+
+        private static void MilestoneDrawer(ImGui gui, FactorioObject element, int index)
         {
             var settings = Project.current.settings;
-            using (var grid = gui.EnterInlineGrid(3f))
+            var unlocked = settings.Flags(element).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
+            if (gui.BuildFactorioObjectButton(element, 3f, display: MilestoneDisplay.None, bgColor: unlocked ? SchemeColor.Primary : SchemeColor.None))
             {
-                foreach (var cur in settings.milestones)
+                if (!unlocked)
                 {
-                    grid.Next();
-                    var unlocked = settings.Flags(cur).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
-                    if (gui.BuildFactorioObjectButton(cur, 3f, MilestoneDisplay.None, unlocked ? SchemeColor.Primary : SchemeColor.None))
+                    var massUnlock = Milestones.Instance.milestoneResult[element];
+                    var subIndex = 0;
+                    settings.SetFlag(element, ProjectPerItemFlags.MilestoneUnlocked, true);
+                    foreach (var milestone in settings.milestones)
                     {
-                        if (!unlocked)
-                        {
-                            var massUnlock = Milestones.Instance.milestoneResult[cur];
-                            var subIndex = 0;
-                            settings.SetFlag(cur, ProjectPerItemFlags.MilestoneUnlocked, true);
-                            foreach (var milestone in settings.milestones)
-                            {
-                                subIndex++;
-                                if ((massUnlock & (1ul << subIndex)) != 0)
-                                    settings.SetFlag(milestone, ProjectPerItemFlags.MilestoneUnlocked, true);
-                            }
-                        }
-                        else
-                        {
-                            settings.SetFlag(cur, ProjectPerItemFlags.MilestoneUnlocked, false);
-                        }
+                        subIndex++;
+                        if ((massUnlock & (1ul << subIndex)) != 0)
+                            settings.SetFlag(milestone, ProjectPerItemFlags.MilestoneUnlocked, true);
                     }
-                    if (unlocked && gui.isBuilding)
-                        gui.DrawIcon(gui.lastRect, Icon.Check, SchemeColor.Error);
+                }
+                else
+                {
+                    settings.SetFlag(element, ProjectPerItemFlags.MilestoneUnlocked, false);
                 }
             }
+            if (unlocked && gui.isBuilding)
+                gui.DrawIcon(gui.lastRect, Icon.Check, SchemeColor.Error);
+
         }
+
     }
-    
+
     public class MilestonesPanel : PseudoScreen
     {
         public static readonly MilestonesPanel Instance = new MilestonesPanel();
@@ -53,14 +55,14 @@ namespace YAFC
             gui.AllocateSpacing(2f);
             MilestonesWidget.Instance.Build(gui);
             gui.AllocateSpacing(2f);
-            gui.BuildText("For your convinience, YAFC will show objects you DON'T have access to based on this selection", wrap:true);
+            gui.BuildText("For your convenience, YAFC will show objects you DON'T have access to based on this selection", wrap: true);
             gui.BuildText("These are called 'Milestones'. By default all science packs are added as milestones, but this does not have to be this way! " +
                           "You can define your own milestones: Any item, recipe, entity or technology may be added as a milestone. For example you can add advanced " +
                           "electronic circuits as a milestone, and YAFC will display everything that is locked behind those circuits", wrap: true);
             using (gui.EnterRow())
             {
                 if (gui.BuildButton("Edit milestones", SchemeColor.Grey))
-                    MilestonesEditor.Show(); 
+                    MilestonesEditor.Show();
                 if (gui.RemainingRow().BuildButton("Done"))
                     Close();
             }

--- a/YAFCmodel.Tests/Analysis/Milestones.cs
+++ b/YAFCmodel.Tests/Analysis/Milestones.cs
@@ -1,0 +1,108 @@
+using System.Reflection;
+using System.Collections.Generic;
+using Xunit;
+
+namespace YAFC.Model.Tests
+{
+    public class MilestonesTests
+    {
+        private static Milestones setupMilestones(ulong result, ulong mask, out FactorioObject factorioObj)
+        {
+            factorioObj = new Technology();
+            var milestoneResult = new Mapping<FactorioObject, ulong>(new FactorioIdRange<FactorioObject>(0, 1, new List<FactorioObject>() {
+                factorioObj
+            }));
+            milestoneResult[factorioObj] = result;
+
+            var milestones = new Milestones()
+            {
+                milestoneResult = milestoneResult,
+                currentMilestones = new FactorioObject[] { factorioObj }
+            };
+
+            var milestonesType = typeof(Milestones);
+            var milestonesLockedMask = milestonesType.GetProperty("lockedMask");
+            milestonesLockedMask.SetValue(milestones, mask);
+
+            return milestones;
+        }
+
+        [Theory]
+        [InlineData(0, 1, false)]
+        [InlineData(1, 0, false)]
+        [InlineData(1, 1, true)]
+        [InlineData(3, 1, true)]
+        [InlineData(1, 3, true)]
+        public void IsAccessibleWithCurrentMilestones_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool expectedResult)
+        {
+            var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
+
+            Assert.Equal(expectedResult, milestones.IsAccessibleWithCurrentMilestones(0));
+            Assert.Equal(expectedResult, milestones.IsAccessibleWithCurrentMilestones(factorioObj));
+        }
+
+        [Theory]
+        [InlineData(1, 1, true)]
+        [InlineData(3, 3, false)]
+        [InlineData(15, 15, false)] // Triggers last return
+        [InlineData(16, 16, false)] // Triggers last return
+        [InlineData(17, 17, false)] // Caught by 'bit 0 check', otherwise last return would return true
+        public void IsAccessibleAtNextMilestone_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool expectedResult)
+        {
+            var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
+
+            Assert.Equal(expectedResult, milestones.IsAccessibleAtNextMilestone(factorioObj));
+        }
+
+        [Theory]
+        [InlineData(false, ~0ul)] // all bits set (nothing gets masked)
+        [InlineData(true, ~0ul & ~2ul)] // all bits set, except bit 1 (for reasons not bit 0, even if the FIRST milestone has its flag set?!)
+        public void GetLockedMaskFromProject_ShouldCalculateMask(bool unlocked, ulong expectedResult)
+        {
+            var milestonesType = typeof(Milestones);
+            var getLockedMaskFromProject = milestonesType.GetMethod("GetLockedMaskFromProject", BindingFlags.NonPublic | BindingFlags.Instance);
+            var projectField = milestonesType.GetField("project", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var milestones = setupMilestones(0, 0, out FactorioObject factorioObj);
+
+            var project = new Project();
+            if (unlocked)
+            {
+                // Can't use SetFlag() as it uses the Undo system, which requires SDL
+                var flags = project.settings.itemFlags;
+                flags[factorioObj] = ProjectPerItemFlags.MilestoneUnlocked;
+                var projectType = typeof(ProjectSettings);
+                var itemFlagsField = projectType.GetField("<itemFlags>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance);
+                itemFlagsField.SetValue(project.settings, flags);
+            }
+
+
+            projectField.SetValue(milestones, project);
+
+            getLockedMaskFromProject.Invoke(milestones, null);
+
+            Assert.Equal(expectedResult, milestones.lockedMask);
+        }
+
+        [Theory]
+        [InlineData(1, 0, true, false)]  // HighestBitSet() - 1, so bit 0 is never in range...
+        [InlineData(2, 0, true, true)] // mask is ignored -> true
+        [InlineData(2, 0, false, false)] // mask is active -> false
+        [InlineData(2, 2, true, true)]
+        [InlineData(2, 2, false, true)] // mask is active and overlaps -> true
+        [InlineData(4, 0, true, false)]  // HighestBitSet() too large...
+        public void GetHighest_WhenGivenMilestones_ShouldReturnCorrectValue(ulong result, ulong mask, bool all, bool expectObject)
+        {
+            var milestones = setupMilestones(result, mask, out FactorioObject factorioObj);
+
+            if (expectObject)
+            {
+                Assert.Equal(factorioObj, milestones.GetHighest(factorioObj, all));
+            }
+            else
+            {
+                Assert.Null(milestones.GetHighest(factorioObj, all));
+            }
+        }
+    }
+}

--- a/YAFCmodel.Tests/Math/Bits.cs
+++ b/YAFCmodel.Tests/Math/Bits.cs
@@ -1,0 +1,457 @@
+using System.Reflection;
+using Xunit;
+
+namespace YAFC.Model.Tests
+{
+    public class BitsTests
+    {
+        [Fact]
+        public void New_WhenTrueIsProvided_ShouldHaveBit0Set()
+        {
+            var bits = new Bits(true);
+
+            Assert.True(bits[0]);
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(33)]
+        [InlineData(75)]
+        public void SetBit_WhenGivenABit_ShouldReturnSetBit(int bit)
+        {
+            var bits = new Bits();
+
+            bits[bit] = true;
+
+            Assert.True(bits[bit], "Set bit should be set");
+            for (int i = 0; i <= 128; i++)
+            {
+                if (i != bit)
+                    Assert.False(bits[i], "Other bits should be clear");
+            }
+        }
+
+        [Fact]
+        public void IsClear_WhenNotBitsAreSet_ShouldReturnTrue()
+        {
+            var bits = new Bits();
+
+            Assert.True(bits.IsClear(), "IsClear() should return true, as no bits are set");
+        }
+
+        [Fact]
+        public void IsClear_WhenABitSet_ShouldReturnFalse()
+        {
+            var bits = new Bits();
+
+            bits[2] = true;
+
+            Assert.False(bits.IsClear(), "IsClear() should return false, as bit 2 is set");
+        }
+
+        [Theory]
+        [InlineData(new int[] { })]
+        [InlineData(new int[] { 0 })]
+        [InlineData(new int[] { 1 })]
+        [InlineData(new int[] { 1, 10 })]
+        [InlineData(new int[] { 1, 76, 42, 3, 11, 68 })]
+        public void HighestBitSet_WithGivenListOfBits_ShouldReturnHighestBit(int[] bitsToSet)
+        {
+            var bits = new Bits();
+            var highestBit = -1;
+
+            foreach (int bit in bitsToSet)
+            {
+                if (bit > highestBit)
+                    highestBit = bit;
+                bits[bit] = true;
+            }
+
+            Assert.Equal(highestBit, bits.HighestBitSet());
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(24, 42)]
+        public void AndOperator_WithGivenInputBits_ShouldReturnANDedBits(ulong aValue, ulong bValue)
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { aValue });
+            bitsData.SetValue(b, new ulong[] { bValue });
+            bitsLength.SetValue(a, 8);
+            bitsLength.SetValue(b, 8);
+
+            var result = a & b;
+
+            var resultValue = ((ulong[])bitsData.GetValue(result))[0];
+
+            Assert.Equal(aValue & bValue, resultValue);
+        }
+
+        [Fact]
+        public void AndOperator_WithOneLargeValue_ReturnCorrectBits()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsData.SetValue(b, new ulong[] { 4 });
+            bitsLength.SetValue(a, 128);
+            bitsLength.SetValue(b, 128);
+
+            var result = a & b;
+
+            var resultValue = (ulong[])bitsData.GetValue(result);
+
+            Assert.Equal((ulong)4 & 4, resultValue[0]);
+            Assert.Equal(0ul, resultValue[1]);
+        }
+
+        [Fact]
+        public void AndOperator_WithLargeValues_ReturnCorrectBits()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsData.SetValue(b, new ulong[] { 4, 1 });
+            bitsLength.SetValue(a, 128);
+            bitsLength.SetValue(b, 128);
+
+            var result = a & b;
+
+            var resultValue = (ulong[])bitsData.GetValue(result);
+
+            Assert.Equal((ulong)4 & 4, resultValue[0]);
+            Assert.Equal((ulong)3 & 1, resultValue[1]);
+        }
+
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(1, 1)]
+        [InlineData(24, 42)]
+        public void OrOperator_WithGivenInputBits_ShouldReturnORedBits(ulong aValue, ulong bValue)
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { aValue });
+            bitsData.SetValue(b, new ulong[] { bValue });
+            bitsLength.SetValue(a, 8);
+            bitsLength.SetValue(b, 8);
+
+            var result = a | b;
+
+            var resultValue = ((ulong[])bitsData.GetValue(result))[0];
+
+            Assert.Equal(aValue | bValue, resultValue);
+        }
+
+        [Fact]
+        public void OrOperator_WithOneLargeValue_ReturnCorrectBits()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsData.SetValue(b, new ulong[] { 4 });
+            bitsLength.SetValue(a, 128);
+            bitsLength.SetValue(b, 128);
+
+            var result = a | b;
+
+            var resultValue = (ulong[])bitsData.GetValue(result);
+
+            Assert.Equal((ulong)4 | 4, resultValue[0]);
+            Assert.Equal(3ul, resultValue[1]);
+        }
+
+        [Fact]
+        public void OrOperator_WithLargeValues_ReturnCorrectBits()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsData.SetValue(b, new ulong[] { 4, 1 });
+            bitsLength.SetValue(a, 128);
+            bitsLength.SetValue(b, 128);
+
+            var result = a | b;
+
+            var resultValue = (ulong[])bitsData.GetValue(result);
+
+            Assert.Equal((ulong)4 | 4, resultValue[0]);
+            Assert.Equal((ulong)3 | 1, resultValue[1]);
+        }
+
+        [Theory]
+        [InlineData(0, 0 << 1)]
+        [InlineData(1, 1 << 1)]
+        [InlineData(24, 24 << 1)]
+        public void ShiftLeftOperator_WithGivenInputBits_ShouldReturnShiftedBits(ulong aValue, ulong expectedValue)
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            bitsData.SetValue(a, new ulong[] { aValue });
+            bitsLength.SetValue(a, 8);
+
+            var result = a << 1;
+
+            var resultValue = ((ulong[])bitsData.GetValue(result))[0];
+
+            Assert.Equal(expectedValue, resultValue);
+        }
+
+        [Theory]
+        [InlineData(1, 1)] // only subtracting by 1 is supported
+        [InlineData(42, 1)]
+        public void SubtractOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue)
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            bitsData.SetValue(a, new ulong[] { aValue });
+            bitsLength.SetValue(a, 8);
+
+            var result = a - bValue;
+
+            var resultValue = ((ulong[])bitsData.GetValue(result))[0];
+
+            Assert.Equal(aValue - bValue, resultValue);
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        public void EqualOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue)
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            bitsData.SetValue(a, new ulong[] { aValue });
+            bitsLength.SetValue(a, 8);
+
+            var result = a == bValue;
+
+            Assert.Equal(aValue == bValue, result);
+        }
+
+        [Fact]
+
+        public void EqualOperator_WithLargeValues_ShouldReturnCorrectResult()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsLength.SetValue(a, 128);
+
+            var result = a == 4;
+
+            // First data element matches, but next one is not zero
+            Assert.False(result);
+
+            bitsData.SetValue(a, new ulong[] { 4, 0 });
+
+            var result2 = a == 4;
+
+            // First data element matches and rest is cleared (zero)
+            Assert.True(result2);
+        }
+
+        [Fact]
+        public void EqualOperator_WithSameValueDifferentLengths_ShouldReturnCorrectResult()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsData.SetValue(b, new ulong[] { 4, 3 });
+            bitsLength.SetValue(a, 128);
+            bitsLength.SetValue(b, 126); // drop some zeros
+
+            Assert.True(a == b);
+        }
+
+        [Fact]
+        public void EqualOperator_WithNull_ShouldReturnFalse()
+        {
+            Bits a = null;
+            var result = a == 0;
+
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        public void UnequalOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue)
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            bitsData.SetValue(a, new ulong[] { aValue });
+            bitsLength.SetValue(a, 8);
+
+            var result = a != bValue;
+
+            Assert.Equal(aValue != bValue, result);
+        }
+
+        [Fact]
+        public void UnequalOperator_WithLargeValues_ShouldReturnCorrectResult()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsLength.SetValue(a, 128);
+
+            var result = a != 4;
+
+            // First data element matches, but next one is not zero so unequal
+            Assert.True(result);
+
+            bitsData.SetValue(a, new ulong[] { 4, 0 });
+
+            var result2 = a != 4;
+
+            Assert.False(result2);
+        }
+
+        [Fact]
+        public void UnequalOperator_WithSameValueDifferentLengths_ShouldReturnCorrectResult()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsData.SetValue(b, new ulong[] { 4, 3 });
+            bitsLength.SetValue(a, 128);
+            bitsLength.SetValue(b, 126); // drop some zeros
+
+            // Number of bits does not matter, so a == b
+            Assert.False(a != b);
+        }
+
+
+        [Fact]
+        public void UnequalOperator_WithNull_ShouldReturnFalse()
+        {
+            Bits a = null;
+            var result = a != 0;
+
+            Assert.False(result);
+        }
+        [Fact]
+        public void SubtractOperator_WithLongInputBits_ShouldReturnCorrectResult()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            bitsData.SetValue(a, new ulong[] { 0, 3 });
+            bitsLength.SetValue(a, 128);
+
+            var result = a - 1;
+
+
+            var resultValue = (ulong[])bitsData.GetValue(result);
+
+            Assert.Equal(~0ul, resultValue[0]);
+            Assert.Equal(2ul, resultValue[1]);
+        }
+
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 1)]
+        public void LesserThanOperator_WithGivenInputBits_ShouldReturnCorrectResult(ulong aValue, ulong bValue)
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { aValue });
+            bitsData.SetValue(b, new ulong[] { bValue });
+            bitsLength.SetValue(a, 8);
+            bitsLength.SetValue(b, 8);
+
+            var result = a < b;
+
+            Assert.Equal(aValue < bValue, result);
+        }
+
+        [Fact]
+
+        public void LesserThanOperator_WithLargeValues_ShouldReturnCorrectResult()
+        {
+            var bitsType = typeof(Bits);
+            var bitsData = bitsType.GetField("data", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var bitsLength = bitsType.GetField("_length", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var a = new Bits();
+            var b = new Bits();
+            bitsData.SetValue(a, new ulong[] { 4, 3 });
+            bitsData.SetValue(b, new ulong[] { 3, 3 });
+            bitsLength.SetValue(a, 128);
+            bitsLength.SetValue(b, 128);
+
+            var result = a < b;
+
+            // Second data element matches, but first one is not lesser
+            Assert.False(result);
+
+            bitsData.SetValue(a, new ulong[] { 2, 3 });
+
+            var result2 = a < b;
+
+            // Second data element matches, but first one is lesser
+            Assert.True(result2);
+        }
+    }
+}

--- a/YAFCmodel.Tests/YAFCmodel.Tests.csproj
+++ b/YAFCmodel.Tests/YAFCmodel.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\YAFCmodel\YAFCmodel.csproj" />
+    <ProjectReference Include="..\YAFCparser\YAFCparser.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/YAFCmodel/Analysis/Analysis.cs
+++ b/YAFCmodel/Analysis/Analysis.cs
@@ -36,8 +36,8 @@ namespace YAFC.Model
 
     public static class AnalysisExtensions
     {
-        public static bool IsAccessible(this FactorioObject obj) => Milestones.Instance.milestoneResult[obj] != 0;
-        public static bool IsAccessibleWithCurrentMilestones(this FactorioObject obj) => Milestones.Instance.IsAccessibleWithCurrentMilesones(obj);
+        public static bool IsAccessible(this FactorioObject obj) => Milestones.Instance.GetMilestoneResult(obj) != 0;
+        public static bool IsAccessibleWithCurrentMilestones(this FactorioObject obj) => Milestones.Instance.IsAccessibleWithCurrentMilestones(obj);
         public static bool IsAutomatable(this FactorioObject obj) => AutomationAnalysis.Instance.automatable[obj] != AutomationStatus.NotAutomatable;
         public static bool IsAutomatableWithCurrentMilestones(this FactorioObject obj) => AutomationAnalysis.Instance.automatable[obj] == AutomationStatus.AutomatableNow;
         public static float Cost(this FactorioObject goods, bool atCurrentMilestones = false) => CostAnalysis.Get(atCurrentMilestones).cost[goods];

--- a/YAFCmodel/Analysis/AutomationAnalysis.cs
+++ b/YAFCmodel/Analysis/AutomationAnalysis.cs
@@ -52,7 +52,7 @@ namespace YAFC.Model
             {
                 var index = processingQueue.Dequeue();
                 var dependencies = Dependencies.dependencyList[index];
-                var automationState = Milestones.Instance.IsAccessibleWithCurrentMilesones(index) ? AutomationStatus.AutomatableNow : AutomationStatus.AutomatableLater;
+                var automationState = Milestones.Instance.IsAccessibleWithCurrentMilestones(index) ? AutomationStatus.AutomatableNow : AutomationStatus.AutomatableLater;
                 foreach (var depGroup in dependencies)
                 {
                     if (!depGroup.flags.HasFlags(DependencyList.Flags.OneTimeInvestment))
@@ -82,7 +82,7 @@ namespace YAFC.Model
                         var hasMachine = false;
                         foreach (var element in depGroup.elements)
                         {
-                            if (element != Database.character.id && Milestones.Instance.IsAccessibleWithCurrentMilesones(element))
+                            if (element != Database.character.id && Milestones.Instance.IsAccessibleWithCurrentMilestones(element))
                             {
                                 hasMachine = true;
                                 break;

--- a/YAFCmodel/Analysis/Milestones.cs
+++ b/YAFCmodel/Analysis/Milestones.cs
@@ -24,6 +24,7 @@ namespace YAFC.Model
                 return true;
             if ((milestoneMask & 1) != 0)
                 return false;
+            // TODO Always returns false -> milestoneMask is a power of 2 + 1 always has bit 0 set, as x pow 2 sets one (high) bit, so the + 1 adds bit 0, which is detected by (milestoneMask & 1) != 0
             return ((milestoneMask - 1) & (milestoneMask - 2)) == 0; // milestoneMask is a power of 2 + 1
         }
 

--- a/YAFCmodel/Analysis/TechnologyScienceAnalysis.cs
+++ b/YAFCmodel/Analysis/TechnologyScienceAnalysis.cs
@@ -13,10 +13,10 @@ namespace YAFC.Model
         {
             var list = allSciencePacks[tech];
             Ingredient ingr = null;
-            ulong order = 0;
+            var order = new Bits();
             foreach (var elem in list)
             {
-                var elemOrder = Milestones.Instance.milestoneResult[elem.goods.id] - 1;
+                var elemOrder = Milestones.Instance.GetMilestoneResult(elem.goods.id) - 1;
                 if (ingr == null || elemOrder > order)
                 {
                     order = elemOrder;
@@ -26,7 +26,7 @@ namespace YAFC.Model
 
             return ingr;
         }
-        
+
         public override void Compute(Project project, ErrorCollector warnings)
         {
             var sciencePacks = Database.allSciencePacks;
@@ -54,7 +54,7 @@ namespace YAFC.Model
             while (queue.Count > 0)
             {
                 var current = queue.Dequeue();
-                
+
                 // Fast processing for the first prerequisite (just copy everything)
                 if (current.prerequisites.Length > 0)
                 {
@@ -98,8 +98,8 @@ namespace YAFC.Model
 
                         processing[tech] = true;
                         queue.Enqueue(tech);
-                        
-                        locked:;
+
+locked:;
                     }
                 }
             }

--- a/YAFCmodel/Data/DataUtils.cs
+++ b/YAFCmodel/Data/DataUtils.cs
@@ -67,10 +67,15 @@ namespace YAFC.Model
         public static readonly IComparer<FactorioObject> DeterministicComparer = new FactorioObjectDeterministicComparer();
         public static readonly IComparer<Fluid> FluidTemperatureComparer = new FluidTemperatureComparerImp();
 
-        public static ulong GetMilestoneOrder(FactorioId id)
+        public static Bits GetMilestoneOrder(FactorioId id)
         {
             var ms = Milestones.Instance;
-            return (ms.milestoneResult[id] - 1) & ms.lockedMask;
+            if (ms.GetMilestoneResult(id).IsClear())
+            {
+                // subtracting 1 of all zeros would set all bits ANDing this with lockedMask is equal to lockedMask
+                return ms.lockedMask;
+            }
+            return (ms.GetMilestoneResult(id) - 1) & ms.lockedMask;
         }
 
         public static string dataPath { get; internal set; }

--- a/YAFCmodel/Data/Database.cs
+++ b/YAFCmodel/Data/Database.cs
@@ -79,7 +79,7 @@ namespace YAFC.Model
         public int count { get; }
         public T[] all { get; }
 
-        internal FactorioIdRange(int start, int end, List<FactorioObject> source)
+        public FactorioIdRange(int start, int end, List<FactorioObject> source)
         {
             this.start = start;
             count = end-start;
@@ -110,7 +110,7 @@ namespace YAFC.Model
         private readonly int offset;
         private readonly TValue[] data;
         private readonly FactorioIdRange<TKey> source;
-        internal Mapping(FactorioIdRange<TKey> source)
+        public Mapping(FactorioIdRange<TKey> source)
         {
             this.source = source;
             data = new TValue[source.count];

--- a/YAFCmodel/Math/Bits.cs
+++ b/YAFCmodel/Math/Bits.cs
@@ -1,0 +1,432 @@
+using System;
+using System.Numerics;
+
+namespace YAFC.Model
+{
+    public class Bits
+    {
+        private int _length;
+        public int length
+        {
+            get => _length;
+            private set
+            {
+                Array.Resize(ref data, (int)Math.Ceiling(value / 64f));
+                _length = value;
+            }
+        }
+        private ulong[] data = Array.Empty<ulong>();
+
+        public bool this[int i]
+        {
+            get
+            {
+                if (length <= i)
+                {
+                    return false;
+                }
+                return (data[i / 64] & (1ul << (i % 64))) != 0;
+            }
+            set
+            {
+                if (length <= i)
+                {
+                    length = i + 1;
+                }
+                if (value)
+                {
+                    // set bit
+                    data[i / 64] |= 1ul << (i % 64);
+                }
+                else
+                {
+                    // clear bit
+                    data[i / 64] &= ~(1ul << (i % 64));
+                }
+            }
+        }
+
+        public Bits() { }
+
+        public Bits(bool setBit0)
+        {
+            if (setBit0)
+            {
+                this[0] = true;
+            }
+        }
+
+        // Make a copy of Bits
+        public Bits(Bits orginal)
+        {
+            if (orginal is null)
+            {
+                return;
+            }
+
+            data = (ulong[])orginal.data.Clone();
+            _length = orginal.length;
+        }
+
+        public static Bits operator &(Bits a, Bits b)
+        {
+            Bits result = new();
+
+            if (a is null && b is null)
+            {
+                return result;
+            }
+
+            // Make sure that a and b are not null
+            a ??= new Bits();
+            b ??= new Bits();
+            result.length = Math.Max(a.length, b.length);
+
+            for (int i = 0; i < result.data.Length; i++)
+            {
+                if (a.data.Length <= i || b.data.Length <= i)
+                {
+                    result.data[i] = 0;
+                }
+                else
+                {
+                    result.data[i] = a.data[i] & b.data[i];
+                }
+            }
+
+            return result;
+        }
+
+        public static Bits operator |(Bits a, Bits b)
+        {
+            Bits result = new();
+
+            if (a is null && b is null)
+            {
+                return result;
+            }
+
+            // Make sure that a and b are not null
+            a ??= new Bits();
+            b ??= new Bits();
+            result.length = Math.Max(a.length, b.length);
+
+            for (int i = 0; i < result.data.Length; i++)
+            {
+                if (a.data.Length <= i)
+                {
+                    result.data[i] = b.data[i];
+                }
+                else if (b.data.Length <= i)
+                {
+                    result.data[i] = a.data[i];
+                }
+                else
+                {
+                    result.data[i] = a.data[i] | b.data[i];
+                }
+            }
+
+            return result;
+        }
+
+        public static Bits operator <<(Bits a, int shift)
+        {
+            if (shift != 1)
+            {
+                throw new NotImplementedException("only shifting by 1 is supported");
+            }
+
+            Bits result = new()
+            {
+                length = a.length + 1
+            };
+
+            // bits that 'fell off' in the previous shifting operation
+            var carrier = 0ul;
+            for (int i = 0; i < a.data.Length; i++)
+            {
+                result.data[i] = (a.data[i] << shift) | carrier;
+                carrier = a.data[i] & ~(~0ul >> shift); // Mask with 'shift amount of MSB'
+            }
+            if (carrier != 0)
+            {
+                // Reason why only shift == 1 is supported, it is messy to map the separate bits back on data[length] and data[length - 1]
+                // Since shift != 1 is never used, its implementation is omitted
+                result[result.length] = true;
+            }
+
+            return result;
+        }
+
+        public static bool operator <(Bits a, Bits b)
+        {
+            if (b is null)
+            {
+                // b doesn't have a value (treat as zeo), so a >= b
+                return false;
+            }
+
+            if (a is null)
+            {
+                // true if b has a bit set (a == 0 and b > 0)
+                return !b.IsClear();
+            }
+
+            var maxLength = Math.Max(a.data.Length, b.data.Length);
+            for (int i = maxLength - 1; i >= 0; i--)
+            {
+                if (a.data.Length <= i)
+                {
+                    if (b.data[i] != 0)
+                    {
+                        // b is larger, so a < b
+                        return true;
+                    }
+                }
+                else if (b.data.Length <= i)
+                {
+                    if (a.data[i] != 0)
+                    {
+                        // a is larger, so a > b
+                        return false;
+                    }
+                }
+                else if (a.data[i] < b.data[i])
+                {
+                    return true;
+                }
+                else if (a.data[i] > b.data[i])
+                {
+                    return false;
+                }
+
+                // bits are equal, go to next pair
+            }
+
+            // a and b are fully equal, so not a < b
+            return false;
+        }
+
+        public static bool operator >(Bits a, Bits b)
+        {
+            if (a is null)
+            {
+                // a doesn't have a possible value, so b >= a
+                return false;
+            }
+
+            if (b is null)
+            {
+                // true if a has a bit set
+                return !a.IsClear();
+            }
+
+            var maxLength = Math.Max(a.data.Length, b.data.Length);
+            for (int i = maxLength - 1; i >= 0; i--)
+            {
+                if (a.data.Length <= i)
+                {
+                    if (b.data[i] != 0)
+                    {
+                        // b is larger, so a < b
+                        return false;
+                    }
+                }
+                else if (b.data.Length <= i)
+                {
+                    if (a.data[i] != 0)
+                    {
+                        // a is larger, so a > b
+                        return true;
+                    }
+                }
+                else if (a.data[i] < b.data[i])
+                {
+                    return false;
+                }
+                else if (a.data[i] > b.data[i])
+                {
+                    return true;
+                }
+
+                // bits are equal, go to next pair
+            }
+
+            // a and b are equal, so not a > b
+            return false;
+        }
+
+        public static Bits operator -(Bits a, ulong b)
+        {
+            if (a.IsClear())
+            {
+                throw new ArgumentOutOfRangeException(nameof(a), "a is 0, so the result would become negative!");
+            }
+
+            if (b != 1)
+            {
+                throw new NotImplementedException("only subtracting by 1 is supported");
+            }
+
+            var result = new Bits(a);
+
+            // Only works for subtracting by 1!
+            // subtract by 1: find lowest bit that is set, unset this bit and set all previous bits
+            var index = 0;
+            while (result[index] == false)
+            {
+                result[index] = true;
+                index++;
+            }
+            result[index] = false;
+
+            return result;
+        }
+
+
+        // Check if the first ulong of a equals to b, rest of a needs to be 0
+        public static bool operator ==(Bits a, ulong b)
+        {
+            if (a is null || a.length == 0 || a.data[0] != b)
+            {
+                return false;
+            }
+
+            for (int i = 1; i < a.data.Length; i++)
+            {
+                if (a.data[i] != 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public static bool operator ==(Bits a, Bits b)
+        {
+            if (a is null && b is null)
+            {
+                return true;
+            }
+
+            if (a is null || b is null)
+            {
+                return false;
+            }
+
+            // Check if a and b have the same 'width' (ignoring zeroed bits)
+            if (a.HighestBitSet() != b.HighestBitSet())
+            {
+                return false;
+            }
+
+            for (int i = Math.Min(a.data.Length, b.data.Length) - 1; i >= 0; i--)
+            {
+                if (a.data[i] != b.data[i])
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+
+        public static bool operator !=(Bits a, Bits b)
+        {
+            if (a is null && b is null)
+            {
+                return false;
+            }
+
+            if (a is null || b is null)
+            {
+                // Either a or b is null
+                return true;
+            }
+
+            // Check if a and b have the same 'width' (ignoring zeroed bits)
+            if (a.HighestBitSet() != b.HighestBitSet())
+            {
+                return true;
+            }
+
+            for (int i = Math.Min(a.data.Length, b.data.Length) - 1; i >= 0; i--)
+            {
+                if (a.data[i] != b.data[i])
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Check if the first ulong of a does not equals to b or rest of data is not zero
+        public static bool operator !=(Bits a, ulong b)
+        {
+            if (a is null || a.length == 0)
+            {
+                return false;
+            }
+
+            if (a.data[0] != b)
+            {
+                return true;
+            }
+
+            for (int i = 1; i < a.data.Length; i++)
+            {
+                if (a.data[i] != 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool IsClear()
+        {
+            return HighestBitSet() == -1;
+        }
+
+        public int HighestBitSet()
+        {
+            int result = -1;
+            for (int i = 0; i < data.Length; i++)
+            {
+                if (data[i] != 0)
+                {
+                    // data[i] contains a (new) highest bit
+                    result = i * 64 + BitOperations.Log2(data[i]);
+                }
+            }
+
+            return result;
+        }
+
+        public int CompareTo(Bits b)
+        {
+            if (this == b)
+            {
+                return 0;
+            }
+            return this < b ? -1 : 1;
+        }
+
+        public override string ToString()
+        {
+            var bitsString = new System.Text.StringBuilder(8);
+
+            foreach (ulong bits in data)
+            {
+                bitsString.Append(Convert.ToString((long)bits, 2));
+            }
+
+            return bitsString.ToString();
+        }
+    }
+}

--- a/YAFCui/Core/MathUtils.cs
+++ b/YAFCui/Core/MathUtils.cs
@@ -34,19 +34,7 @@ namespace YAFC.UI
                 return 255;
             return (byte) MathF.Round(f * 255);
         }
-        
-        public static int HighestBitSet(ulong x)
-        {
-            var set = 0;
-            if (x > 0xFFFFFFFF) { set += 32; x >>= 32; }
-            if (x > 0xFFFF) { set += 16; x >>= 16; }
-            if (x > 0xFF) { set += 8; x >>= 8; }
-            if (x > 0xF) { set += 4; x >>= 4; }
-            if (x > 0x3) { set += 2; x >>= 2; }
-            if (x > 0x1) { set += 1; }
-            return set;
-        }
-        
+
         public static float LogarithmicToLinear(float value, float logmin, float logmax)
         {
             if (value < 0f)


### PR DESCRIPTION
By embedding the milestone elements in a (virtual) scroll list, it will be possible to scroll them, which lifts the restriction of only allowing 60 milestones.

_Edit_: Fixed the original (probably) reason for this limitation: `ulong` can only hold 64 bits, and the Analyser uses bits to keep track of the dependencies of the milestones (and other objects). By replacing `ulong` with the custom build `Bits` class, this limitation is lifted.

Background: when playing extensive mod packs with lots of new/unknown technologies it is often hard to determine the research path to take. I find it convenient to add a lot (all) technologies to the milestone list, so YAFC shows which technologies I should research to unlock some item/recipe.