### PR TITLE
Support filtering on Factorio type

### DIFF
--- a/YAFCmodel/Data/DataUtils.cs
+++ b/YAFCmodel/Data/DataUtils.cs
@@ -531,7 +531,8 @@ namespace YAFC.Model
             {   
                 if (obj.name.IndexOf(token, StringComparison.OrdinalIgnoreCase) < 0 &&
                     obj.locName.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0 &&
-                    (obj.locDescr == null || obj.locDescr.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0)) 
+                    (obj.locDescr == null || obj.locDescr.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0) &&
+                    (obj.factorioType == null || obj.factorioType.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0))
                     return false;
             }
 


### PR DESCRIPTION
Related to my reasoning of #203, it is also convenient to only show the technologies, with this PR it is possible to filter on 'Technology' and it only shows the Technologies in the milestone selector.

When this is combined with the #168 it is even more powerful.